### PR TITLE
Allow serialization of null structs

### DIFF
--- a/lib/ja_serializer.ex
+++ b/lib/ja_serializer.ex
@@ -55,8 +55,12 @@ defmodule JaSerializer do
   the conn and opts and returns a map ready for json encoding.
   """
   def format(serializer, data, conn \\ %{}, opts \\ []) do
-    %{data: data, conn: conn, serializer: serializer, opts: opts}
-    |> JaSerializer.Builder.build
-    |> JaSerializer.Formatter.format
+    cond do
+      data ->
+        %{data: data, conn: conn, serializer: serializer, opts: opts}
+        |> JaSerializer.Builder.build
+        |> JaSerializer.Formatter.format
+      is_nil(data) -> %{data: nil}
+    end
   end
 end

--- a/lib/ja_serializer/phoenix_view.ex
+++ b/lib/ja_serializer/phoenix_view.ex
@@ -110,21 +110,20 @@ defmodule JaSerializer.PhoenixView do
   end
 
   defp find_struct(serializer, data) do
-    case data[:data] do
-      nil ->
-        singular = singular_type(serializer.type)
-        plural = plural_type(serializer.type)
+    singular = singular_type(serializer.type)
+    plural = plural_type(serializer.type)
+    deprecated_struct  = data[:model] || data[singular] || data[plural]
+
+    cond do
+      data[:data] -> data[:data]
+      deprecated_struct ->
         IO.write :stderr, IO.ANSI.format([:red, :bright,
           "warning: Passing data via `:model`, `:#{plural}` or `:#{singular}`
           atoms to JaSerializer.PhoenixView has be deprecated. Please use
           `:data` instead. This will stop working in a future version.\n"
         ])
-
-        data[:model]
-        || data[singular]
-        || data[plural]
-        || raise "Unable to find data to serialize."
-      struct -> struct
+        deprecated_struct
+      is_nil(data[:data]) -> nil
     end
   end
 

--- a/test/ja_serializer/phoenix_view_test.exs
+++ b/test/ja_serializer/phoenix_view_test.exs
@@ -75,6 +75,11 @@ defmodule JaSerializer.PhoenixViewTest do
     assert Dict.has_key?(json["data"], "attributes")
   end
 
+  test "render conn, show.json-api, data: nil" do
+    json = @view.render("show.json-api", conn: %{}, data: nil)
+    assert json['data'] == nil
+  end
+
   # This should be deprecated in the future
   test "render conn, show.json, data: model", c do
     json = @view.render("show.json", conn: %{}, data: c[:m1])


### PR DESCRIPTION
Hi,

First of all, thanks for this package, it's really great and has been very useful to me.

I have encountered a small problem while using it, let's say a have a resource (car for example) and another resource associated to it (insurance_data for example). The car may or may not have an insurance_data record associated to it and insurance_data records don't make sense if they are not associated to a car.

Given this reality I built a car serializer that has a belongs_to association to a insurance_data resource which (`link: [related: 'cars/:id/insurance_data']`).

I created and endpoint that given a car returns its insurance data:
`render(conn, "show.json-api", data: insurance_data)`.

When `insurance_data` is present, everything works as expected, the problem arises when the car doesn't have an insurance_data record associated to it.

`ja_serializer` is not allowing nil values to be serialized but the JSON API specification [allows it](http://jsonapi.org/format/#document-top-level).

```
Primary data MUST be either:

    a single resource object, a single resource identifier object, or null, for requests that target single resources
    an array of resource objects, an array of resource identifier objects, or an empty array ([]), for requests that target resource collections
```

This PR attempts to fix that behavior.
