### PR TITLE
Allow pagination link keys to be configured

### DIFF
--- a/lib/ja_serializer/builder/scrivener_links.ex
+++ b/lib/ja_serializer/builder/scrivener_links.ex
@@ -1,6 +1,8 @@
 if Code.ensure_loaded?(Scrivener) do
   defmodule JaSerializer.Builder.ScrivenerLinks do
 
+    import JaSerializer.Formatter.Utils, only: [format_key: 1]
+
     @moduledoc """
     Builds JSON-API spec pagination links for %Scrivener.Page{}.
     """
@@ -28,14 +30,24 @@ if Code.ensure_loaded?(Scrivener) do
       do: [self: n, first: 1, prev: n - 1, next: n + 1, last: t]
 
     defp page_url(num, base, page_size, orginal_params) do
-      params = orginal_params
-      |> Dict.merge(%{page_key => %{page_key => num, page_size_key => page_size}})
-      |> Plug.Conn.Query.encode
+      params =
+        orginal_params
+        |> Map.merge(%{page_key => %{page_number_key => num, page_size_key => page_size}})
+        |> Plug.Conn.Query.encode
 
       "#{base}?#{params}"
     end
 
-    defp page_key, do: JaSerializer.Formatter.Utils.format_key("page")
-    defp page_size_key, do: JaSerializer.Formatter.Utils.format_key("page_size")
+    defp page_key do
+      Application.get_env(:ja_serializer, :page_key, format_key("page"))
+    end
+
+    defp page_number_key do
+      Application.get_env(:ja_serializer, :page_number_key, format_key("page"))
+    end
+
+    defp page_size_key do
+      Application.get_env(:ja_serializer, :page_size_key, format_key("page_size"))
+    end
   end
 end

--- a/test/ja_serializer/builder/scrivener_links_test.exs
+++ b/test/ja_serializer/builder/scrivener_links_test.exs
@@ -21,6 +21,33 @@ defmodule JaSerializer.Builder.ScrivenerLinksTest do
     assert URI.decode(links[:last]) == "?page[page]=30&page[page-size]=20"
   end
 
+  test "pagination keys are configurable" do
+    Application.put_env(:ja_serializer, :page_key, "page")
+    Application.put_env(:ja_serializer, :page_number_key, "number")
+    Application.put_env(:ja_serializer, :page_size_key, "size")
+
+    page = %Scrivener.Page{
+      page_number: 10,
+      page_size: 20,
+      total_pages: 30
+    }
+    context = %{
+      data: page,
+      conn: %Plug.Conn{query_params: %{}},
+      serializer: PersonSerializer,
+      opts: []
+    }
+    links = ScrivenerLinks.build(context)
+    assert URI.decode(links[:first]) == "?page[number]=1&page[size]=20"
+    assert URI.decode(links[:prev]) == "?page[number]=9&page[size]=20"
+    assert URI.decode(links[:next]) == "?page[number]=11&page[size]=20"
+    assert URI.decode(links[:last]) == "?page[number]=30&page[size]=20"
+
+    Application.delete_env(:ja_serializer, :page_key)
+    Application.delete_env(:ja_serializer, :page_number_key)
+    Application.delete_env(:ja_serializer, :page_size_key)
+  end
+
   test "when current page is first, do not include first, prev links" do
     page = %Scrivener.Page{
       page_number: 1,


### PR DESCRIPTION
This PR allows the pagination links to be configured as desired, but maintains the original
as defaults.