### PR TITLE
Fixes typos in EctoErrorSerializer

### DIFF
--- a/lib/ja_serializer/ecto_error_serializer.ex
+++ b/lib/ja_serializer/ecto_error_serializer.ex
@@ -13,8 +13,8 @@ defmodule JaSerializer.EctoErrorSerializer do
   %{"errors" => [
      %{
        source: %{pointer: "/data/attributes/monies"},
-       title: "must be more then 10",
-       detail: "Monies must be more then 10"
+       title: "must be more than 10",
+       detail: "Monies must be more than 10"
       }
     ]
   }

--- a/test/ja_serializer/ecto_error_serializer_test.exs
+++ b/test/ja_serializer/ecto_error_serializer_test.exs
@@ -24,8 +24,8 @@ defmodule JaSerializer.EctoErrorSerializerTest do
       "errors" => [
         %{
           source: %{pointer: "/data/attributes/monies"},
-          title: "must be more then 10",
-          detail: "Monies must be more then 10"
+          title: "must be more than 10",
+          detail: "Monies must be more than 10"
         }
       ]
     }
@@ -34,7 +34,7 @@ defmodule JaSerializer.EctoErrorSerializerTest do
       Ecto.Changeset.add_error(
         %Ecto.Changeset{},
         :monies,
-        "must be more then %{count}",
+        "must be more than %{count}",
         [count: 10]
       )
     )


### PR DESCRIPTION
Fixes all the typos where "then" was put instead of "than"