### PR TITLE
Put `jsonapi version` in error responses

### DIFF
--- a/lib/ja_serializer/error_serializer.ex
+++ b/lib/ja_serializer/error_serializer.ex
@@ -9,24 +9,25 @@ defmodule JaSerializer.ErrorSerializer do
   See http://jsonapi.org/format/#error-objects for more on errors.
   """
 
+  alias JaSerializer.Builder.TopLevel
+  alias JaSerializer.Formatter
+
   def format(error), do: format(error, %{})
   def format(error, conn), do: format(error, conn, [])
   def format(errors, _conn, _opts) when is_list(errors) do
-    errors
-    |> Enum.map(&format_one/1)
-    |> as_json
+    errors = errors |> Enum.map(&format_one/1)
+    %TopLevel{errors: errors} |> Formatter.format
   end
   def format(error, _conn, _opts) do
-    error
+    errors = error
     |> format_one
     |> List.wrap
-    |> as_json
+
+    %TopLevel{errors: errors} |> Formatter.format
   end
 
   @error_fields ~w(id links about status code title detail source meta)a
   defp format_one(error) do
     Dict.take(error, @error_fields)
   end
-
-  defp as_json(errors), do: %{"errors" => errors}
 end

--- a/lib/ja_serializer/formatter/top_level.ex
+++ b/lib/ja_serializer/formatter/top_level.ex
@@ -1,22 +1,31 @@
 defimpl JaSerializer.Formatter, for: JaSerializer.Builder.TopLevel do
   alias JaSerializer.Formatter.Utils
 
-  def format(struct) do
-    %{"jsonapi" =>  %{"version" => "1.0"}}
-    |> Map.put("data", JaSerializer.Formatter.format(struct.data))
+  @jsonapi_version "1.0"
+
+  def format(struct = %{errors: nil}) do
+    %{"data" =>  JaSerializer.Formatter.format(struct.data)}
     |> format_links(struct.links)
     |> Utils.put_if_present("meta", JaSerializer.Formatter.format(struct.meta))
     |> Utils.put_if_present("included", JaSerializer.Formatter.format(struct.included))
+    |> put_version
+  end
+
+  def format(struct = %{data: nil}) do
+    %{"errors" =>  JaSerializer.Formatter.format(struct.errors)} |> put_version
   end
 
   defp format_links(resource, nil), do: resource
   defp format_links(resource, []), do: resource
-
   defp format_links(resource, links) do
     links = links
             |> JaSerializer.Formatter.format
             |> Enum.reject(&(is_nil(&1)))
             |> Enum.into(%{})
     Map.put(resource, "links", links)
+  end
+
+  defp put_version(resource) do
+    resource |> Map.put("jsonapi", %{"version" => @jsonapi_version})
   end
 end

--- a/test/ja_serializer/ecto_error_serializer_test.exs
+++ b/test/ja_serializer/ecto_error_serializer_test.exs
@@ -11,7 +11,8 @@ defmodule JaSerializer.EctoErrorSerializerTest do
           title: "is invalid",
           detail: "Title is invalid"
         }
-      ]
+      ],
+      "jsonapi" => %{"version" => "1.0"}
     }
 
     assert expected == EctoErrorSerializer.format(
@@ -27,7 +28,8 @@ defmodule JaSerializer.EctoErrorSerializerTest do
           title: "must be more then 10",
           detail: "Monies must be more then 10"
         }
-      ]
+      ],
+      "jsonapi" => %{"version" => "1.0"}
     }
 
     assert expected == EctoErrorSerializer.format(
@@ -53,7 +55,8 @@ defmodule JaSerializer.EctoErrorSerializerTest do
           title: "is invalid",
           detail: "Title is invalid"
         }
-      ]
+      ],
+      "jsonapi" => %{"version" => "1.0"}
     }
 
     changeset = %Ecto.Changeset{}
@@ -66,17 +69,18 @@ defmodule JaSerializer.EctoErrorSerializerTest do
   test "Support additional fields per the JSONAPI standard" do
     expected = %{
       "errors" => [
-      %{
-        id: "1",
-        status: "422",
-        code: "1000",
-        title: "is invalid",
-        detail: "Title is invalid",
-        source: %{pointer: "/data/attributes/title"},
-        links: %{self: "http://localhost"},
-        meta: %{author: "Johnny"}
-      }
-    ]
+        %{
+          id: "1",
+          status: "422",
+          code: "1000",
+          title: "is invalid",
+          detail: "Title is invalid",
+          source: %{pointer: "/data/attributes/title"},
+          links: %{self: "http://localhost"},
+          meta: %{author: "Johnny"}
+        }
+      ],
+      "jsonapi" => %{"version" => "1.0"}
     }
 
     assert expected == EctoErrorSerializer.format(
@@ -93,12 +97,12 @@ defmodule JaSerializer.EctoErrorSerializerTest do
           title: "is invalid",
           detail: "Title is invalid"
         }
-      ]
+      ],
+      "jsonapi" => %{"version" => "1.0"}
     }
 
     assert expected == EctoErrorSerializer.format(
       Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid", type: {:array, :integer})
     )
   end
-
 end

--- a/test/ja_serializer/error_serializer_test.exs
+++ b/test/ja_serializer/error_serializer_test.exs
@@ -4,7 +4,7 @@ defmodule JaSerializer.ErrorSerializerTest do
   alias JaSerializer.ErrorSerializer
 
   test "formatting one error" do
-    expected = %{"errors" => [%{ title: "foo", detail: "bar"}]}
+    expected = %{"errors" => [%{ title: "foo", detail: "bar"}], "jsonapi" => %{"version" => "1.0"}}
     assert expected == ErrorSerializer.format(%{title: "foo", detail: "bar"})
   end
 
@@ -13,7 +13,8 @@ defmodule JaSerializer.ErrorSerializerTest do
       "errors" => [
         %{title: "foo", detail: "baz"},
         %{title: "fu", detail: "bar"}
-      ]
+      ],
+      "jsonapi" => %{"version" => "1.0"}
     }
     assert expected == ErrorSerializer.format([
       %{title: "foo", detail: "baz"},
@@ -22,7 +23,7 @@ defmodule JaSerializer.ErrorSerializerTest do
   end
 
   test "ignore invalid fields" do
-    expected = %{"errors" => [%{title: "foo"}]}
+    expected = %{"errors" => [%{title: "foo"}], "jsonapi" => %{"version" => "1.0"}}
     assert expected == ErrorSerializer.format(%{title: "foo", name: "bar"})
   end
 end


### PR DESCRIPTION
Put the `jsonapi version` in error responses to be more consistent with the non-error responses that include it.