### PR TITLE
Allow character encoding or other attributes in content-type header

### DIFF
--- a/lib/ja_serializer/content_type_negotiation.ex
+++ b/lib/ja_serializer/content_type_negotiation.ex
@@ -32,7 +32,7 @@ defmodule JaSerializer.ContentTypeNegotiation do
   def verify_content_type(%Plug.Conn{method: "GET"} = conn, _o), do: conn
   def verify_content_type(%Plug.Conn{method: "DELETE"} = conn, _o), do: conn
   def verify_content_type(%Plug.Conn{} = conn, _o) do
-    if Enum.member?(get_req_header(conn, "content-type"), @jsonapi) do
+    if Enum.any?(get_req_header(conn, "content-type"), fn(x) -> String.match?(x, ~r/^application\/vnd.api\+json(;.*|;?)$/) end) do
       conn
     else
       halt send_resp(conn, 415, "")

--- a/lib/ja_serializer/content_type_negotiation.ex
+++ b/lib/ja_serializer/content_type_negotiation.ex
@@ -32,7 +32,7 @@ defmodule JaSerializer.ContentTypeNegotiation do
   def verify_content_type(%Plug.Conn{method: "GET"} = conn, _o), do: conn
   def verify_content_type(%Plug.Conn{method: "DELETE"} = conn, _o), do: conn
   def verify_content_type(%Plug.Conn{} = conn, _o) do
-    if Enum.any?(get_req_header(conn, "content-type"), fn(x) -> String.match?(x, ~r/^application\/vnd.api\+json(;.*|;?)$/) end) do
+    if Enum.any?(get_req_header(conn, "content-type"), &String.match?(&1, ~r/^application\/vnd.api\+json(;.*|;?)$/)) do
       conn
     else
       halt send_resp(conn, 415, "")


### PR DESCRIPTION
I'm going to leave this pull request here so I can initiate a discussion about this. We came across an issue where an Android app (built with React Native) was trying to integrate with our API, however it seems that Android attaches character encoding properties to the content-type header e.g. `application/vnd.api+json; charset=utf-8`.

I see that in your tests you've defined `application/vnd.api+json; charset=utf-8` as an invalid content type, is there a reason behind this?