### PR TITLE
Allow configuration for global Scrivener base_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,11 +345,19 @@ option.
 render conn, data: page, opts: [page: [base_url: "http://example.com/foos"]]
 ```
 
+You can also configure `ja_serializer` to use a global default URL
+base for all links.
+
+```elixir
+config :ja_serializer,
+  scrivener_base_url: "http://example.com:4000/v1/"
+```
+
 *Note*: The resulting URLs will use the JSON-API recommended `page` query
 param.
 
 Example URL:
-`http://example.com/v1/posts?page[page]=2&page[page-size]=50`
+`http://example.com:4000/v1/posts?page[page]=2&page[page-size]=50`
 
 ### Meta Data
 

--- a/lib/ja_serializer/builder/scrivener_links.ex
+++ b/lib/ja_serializer/builder/scrivener_links.ex
@@ -9,7 +9,7 @@ if Code.ensure_loaded?(Scrivener) do
 
     @spec build(map) :: map
     def build(%{data: data = %Scrivener.Page{}, opts: opts, conn: conn}) do
-      base = opts[:page][:base_url] || conn.request_path
+      base = opts[:page][:base_url] || base_url(conn)
 
       data
       |> pages
@@ -48,6 +48,10 @@ if Code.ensure_loaded?(Scrivener) do
 
     defp page_size_key do
       Application.get_env(:ja_serializer, :page_size_key, format_key("page_size"))
+    end
+
+    defp base_url(conn) do
+      Application.get_env(:ja_serializer, :scrivener_base_url, conn.request_path)
     end
   end
 end


### PR DESCRIPTION
I've found myself wishing I could set a `base_url` once and for all so that each Scrivener-generated pagination links section would use it without me having to pass in the option again and again. With that in mind, I make this proposal.

In order to set a global base_url for all links that don't have their own option passed in, configure the application:

```elixir
config :ja_serializer,
  scrivener_base_url: "http://example.com:4000/v1/"
```

Alternatively, I thought of implementing an option that would allow absolute URLs instead of relative. Something perhaps like this:

```elixir
config :ja_serializer, scrivener_base_url: :absolute # defaults to :relative
```

It would then construct the absolute host/port combo from the `conn` and append the relative path.

The benefit of the implemented method is the ability to specify exactly where the links should head. The benefit of the secondary method is most of the time the links should head to the current host/port combo and thus less `env`-specific configuration is necessary.