### PR TITLE
Fix Warnings For Elixir 1.4

### DIFF
--- a/lib/ja_serializer/builder/scrivener_links.ex
+++ b/lib/ja_serializer/builder/scrivener_links.ex
@@ -32,7 +32,7 @@ if Code.ensure_loaded?(Scrivener) do
     defp page_url(num, base, page_size, orginal_params) do
       params =
         orginal_params
-        |> Map.merge(%{page_key => %{page_number_key => num, page_size_key => page_size}})
+        |> Map.merge(%{page_key() => %{page_number_key() => num, page_size_key() => page_size}})
         |> Plug.Conn.Query.encode
 
       "#{base}?#{params}"

--- a/lib/ja_serializer/dsl.ex
+++ b/lib/ja_serializer/dsl.ex
@@ -63,9 +63,9 @@ defmodule JaSerializer.DSL do
         has_many: 2, has_one: 2, has_many: 1, has_one: 1
       ]
 
-      unquote(define_default_attributes)
-      unquote(define_default_relationships)
-      unquote(define_default_links)
+      unquote(define_default_attributes())
+      unquote(define_default_relationships())
+      unquote(define_default_links())
 
       @before_compile JaSerializer.DSL
     end

--- a/lib/ja_serializer/serializer.ex
+++ b/lib/ja_serializer/serializer.ex
@@ -199,16 +199,16 @@ defmodule JaSerializer.Serializer do
       alias JaSerializer.Relationship.HasOne
 
       # Default Behaviour Callback Defintions
-      unquote(define_default_id)
+      unquote(define_default_id())
       unquote(define_default_type(__CALLER__.module))
-      unquote(define_default_meta)
-      unquote(define_default_links)
-      unquote(define_default_attributes)
-      unquote(define_default_relationships)
-      unquote(define_default_preload)
+      unquote(define_default_meta())
+      unquote(define_default_links())
+      unquote(define_default_attributes())
+      unquote(define_default_relationships())
+      unquote(define_default_preload())
 
       # API to call into serialization
-      unquote(define_api)
+      unquote(define_api())
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,9 +9,9 @@ defmodule JaSerializer.Mixfile do
      start_permanent: Mix.env == :prod,
      consolidate_protocols: Mix.env != :test,
      source_url: "https://github.com/vt-elixir/ja_serializer",
-     package: package,
-     description: description,
-     deps: deps]
+     package: package(),
+     description: description(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
This fixes some of the compiler warnings present, in particular the ones that print every compilation from mix.exs. Strictly speaking, only the first commit is necessary, as that removes the most obnoxious warnings, but I figured I would just add parens everywhere. 

While going through and doing this, I noticed lots of Dict and HashSet deprecation warnings. Is this something that is done for compatibility purposes or has just gotten fixed yet?