### PR TITLE
Update poison to use >= 1.4.0, so that the latest poison can be used

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule JaSerializer.Mixfile do
     [
       {:inflex, "~> 1.4"},
       {:plug, "> 1.0.0"},
-      {:poison, "~> 1.4 or ~> 2.0"},
+      {:poison, ">= 1.4.0"},
       {:ecto, "~> 1.1 or ~> 2.0", only: :test},
       {:earmark, "~> 0.1", only: :dev},
       {:inch_ex, "~> 0.4", only: :docs},


### PR DESCRIPTION
This also updates the other dependencies to their latest versions as
well.

Closes #215.

Let me know if `>=` is the correct syntax to use, as: `~> 1.4 or ~> 2.0 or ~> 3.0` doesn't seem to work.