### PR TITLE
Fix error_serializer with custom structs!?

### DIFF
--- a/lib/ja_serializer/error_serializer.ex
+++ b/lib/ja_serializer/error_serializer.ex
@@ -28,6 +28,6 @@ defmodule JaSerializer.ErrorSerializer do
 
   @error_fields ~w(id links about status code title detail source meta)a
   defp format_one(error) do
-    Dict.take(error, @error_fields)
+    Map.take(error, @error_fields)
   end
 end


### PR DESCRIPTION
`Elixir 1.4`

I created this struct because I want to keep it clean in my application 
```
defmodule MyApp.Error do
  @enforce_keys ~w(status title)a
  defstruct ~w(id links about status code title detail source meta)a
end
```

so I passed it to the serializer with this shape
```
%Error{status: 422,
              title: "Invalid Parameter",
              detail: "User not found"}]
```

but I got an error on https://github.com/vt-elixir/ja_serializer/blob/master/lib/ja_serializer/error_serializer.ex#L31 saying that `take was undefined`.

After that I changed the code to `Map` instead of `Dict` (if I am not wrong `Dict` will be deprecated) and it works fine so I decided to create the PR.
