### PR TITLE
Pluralized types global opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,16 @@ defimpl JaSerializer.Formatter, for: [MyStruct] do
 end
 ```
 
+### Pluralizing All Types By Default
+
+You can opt-in to pluralizing all types for default:
+
+```elixir
+config :ja_serializer,
+  pluralized_type: true
+```
+
+
 ## Complimentary Libraries
 
 * [JaResource](https://github.com/vt-elixir/ja_resource) - WIP behaviour for creating JSON-API controllers in Phoenix.

--- a/lib/ja_serializer/serializer.ex
+++ b/lib/ja_serializer/serializer.ex
@@ -212,18 +212,22 @@ defmodule JaSerializer.Serializer do
 
   defp define_default_type(module) do
     type_from_module = module
-                        |> Atom.to_string
-                        |> String.split(".")
+                        |> Module.split()
                         |> List.last
                         |> String.replace("Serializer", "")
                         |> String.replace("View", "")
-                        |> JaSerializer.Formatter.Utils.format_type
+                        |> JaSerializer.Formatter.Utils.format_type()
+                        |> pluralize_type(Application.get_env(:ja_serializer, :pluralize_types))
     quote do
       def type, do: unquote(type_from_module)
       def type(_data, _conn), do: type()
       defoverridable [type: 2, type: 0]
     end
   end
+
+  defp pluralize_type(type, true),
+    do: Inflex.pluralize(type)
+  defp pluralize_type(type, _bool), do: type
 
   defp define_default_id do
     quote do

--- a/test/ja_serializer/serializer_test.exs
+++ b/test/ja_serializer/serializer_test.exs
@@ -56,4 +56,18 @@ defmodule JaSerializer.SerializerTest do
     assert @serializer.comments(article, %{}) == [:foo]
     assert @view.comments(article, %{}) == [:bar]
   end
+
+  test "it should pluralize the type when declared in config" do
+    Application.put_env(:ja_serializer, :pluralize_types, true)
+
+    defmodule NewArticleSerializer do
+      use JaSerializer
+      attributes [:title, :body]
+      has_many :comments
+    end
+
+    assert NewArticleSerializer.type() == "new-articles"
+
+    Application.delete_env(:ja_serlializer, :pluralized_types)
+  end
 end


### PR DESCRIPTION
Reference issue: #118

Allow API to produce pluralized types rather than having to configure
each serializer one by one.