### PR TITLE
Fix README example for pluralize_types config

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ You can opt-in to pluralizing all types for default:
 
 ```elixir
 config :ja_serializer,
-  pluralized_type: true
+  pluralize_types: true
 ```
 
 


### PR DESCRIPTION
The example was incorrect compared to implementation