### PR TITLE
Parse/format included relationship key paths

### DIFF
--- a/lib/ja_serializer/builder/top_level.ex
+++ b/lib/ja_serializer/builder/top_level.ex
@@ -74,6 +74,7 @@ defmodule JaSerializer.Builder.TopLevel do
   defp normalize_relationship_path_list([path | paths], normalized) do
     normalized = path
     |> String.split(".")
+    |> Enum.map(&JaSerializer.ParamParser.Utils.format_key/1)
     |> normalize_relationship_path
     |> deep_merge_relationship_paths(normalized)
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,7 +2,7 @@ ExUnit.start()
 
 
 defmodule TestModel.Person do
-  defstruct [:id, :first_name, :last_name, :twitter]
+  defstruct [:id, :first_name, :last_name, :twitter, :publishing_agent]
 end
 
 defmodule TestModel.Article do


### PR DESCRIPTION
Addresses #229 

Previously, if a relationship contained multiple words (`has_many :author_comments`) the client would be forced to send `include=author_comments` instead of the expected `author-comments`.

This PR addresses this by utilizing `JaSerializer.ParamParser.Utils.format_key/1`'s format conversion.