### PR TITLE
ja_serializer generator task for phoenix 1.3

### DIFF
--- a/lib/mix/tasks/ja_serializer.gen.phx_api.ex
+++ b/lib/mix/tasks/ja_serializer.gen.phx_api.ex
@@ -1,0 +1,107 @@
+if Code.ensure_loaded?(Phoenix) and Code.ensure_loaded?(Mix.Phoenix.Context) do
+  defmodule Mix.Tasks.JaSerializer.Gen.PhxApi do
+    @shortdoc "Generates a controller and model for a JSON API based resource"
+    
+    use Mix.Task
+
+    alias Mix.Phoenix.Context
+    alias Mix.Tasks.Phx.Gen
+
+    def run(args) do
+      if Mix.Project.umbrella? do
+        Mix.raise "mix phx.gen.json can only be run inside an application directory"
+      end
+
+      {context, schema} = Gen.Context.build(args)
+      binding = [context: context, schema: schema]
+      paths = generator_paths()
+
+      prompt_for_conflicts(context)
+
+      context
+      |> copy_new_files(paths, binding)
+      |> print_shell_instructions()
+    end
+
+    defp generator_paths do
+      [
+        ".",
+        Mix.Project.deps_path |> Path.join("..") |> Path.expand,
+        :ja_serializer,
+        :phoenix
+      ]
+    end
+
+    defp prompt_for_conflicts(context) do
+      context
+      |> files_to_be_generated()
+      |> Kernel.++(context_files(context))
+      |> Mix.Phoenix.prompt_for_conflicts()
+    end
+    defp context_files(%Context{generate?: true} = context) do
+      Gen.Context.files_to_be_generated(context)
+    end
+    defp context_files(%Context{generate?: false}) do
+      []
+    end
+
+    def files_to_be_generated(%Context{schema: schema, context_app: context_app}) do
+      web_prefix = Mix.Phoenix.web_path(context_app)
+      test_prefix = Mix.Phoenix.web_test_path(context_app)
+      web_path = to_string(schema.web_path)
+
+      [
+        {:new_eex, "changeset_view.ex",      Path.join([web_prefix, "views/changeset_view.ex"])},
+        {:new_eex, "fallback_controller.ex", Path.join([web_prefix, "controllers/fallback_controller.ex"])},
+      ]
+    end
+
+    def ja_serializer_files_to_be_generated(%Context{schema: schema, context_app: context_app}) do
+      web_prefix = Mix.Phoenix.web_path(context_app)
+      test_prefix = Mix.Phoenix.web_test_path(context_app)
+      web_path = to_string(schema.web_path)
+
+      [
+        {:eex,     "controller.ex",          Path.join([web_prefix, "controllers", web_path, "#{schema.singular}_controller.ex"])},
+        {:eex,     "view.ex",                Path.join([web_prefix, "views", web_path, "#{schema.singular}_view.ex"])},
+        {:eex,     "controller_test.exs",    Path.join([test_prefix, "controllers", web_path, "#{schema.singular}_controller_test.exs"])},
+      ]
+    end
+
+    def copy_new_files(%Context{} = context, paths, binding) do
+      files = files_to_be_generated(context)
+      Mix.Phoenix.copy_from paths, "priv/templates/phx.gen.json", "", binding, files
+
+      files = ja_serializer_files_to_be_generated(context)
+      Mix.Phoenix.copy_from paths, "priv/templates/ja_serializer.gen.phx_api", "", binding, files
+
+      if context.generate?, do: Gen.Context.copy_new_files(context, paths, binding)
+
+      context
+    end
+
+    def print_shell_instructions(%Context{schema: schema, context_app: ctx_app} = context) do
+      if schema.web_namespace do
+        Mix.shell.info """
+
+        Add the resource to your #{schema.web_namespace} :api scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
+
+            scope "/#{schema.web_path}", #{inspect Module.concat(context.web_module, schema.web_namespace)} do
+              pipe_through :api
+              ...
+              resources "/#{schema.plural}", #{inspect schema.alias}Controller
+            end
+        """
+      else
+        Mix.shell.info """
+
+        Add the resource to your :api scope in lib/#{Mix.Phoenix.otp_app()}/web/router.ex:
+
+            resources "/#{schema.plural}", #{inspect schema.alias}Controller, except: [:new, :edit]
+        """
+      end
+      if context.generate?, do: Gen.Context.print_shell_instructions(context)
+    end
+
+  end
+end

--- a/priv/templates/ja_serializer.gen.phx_api/controller.ex
+++ b/priv/templates/ja_serializer.gen.phx_api/controller.ex
@@ -1,0 +1,43 @@
+defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Controller do
+  use <%= inspect context.web_module %>, :controller
+
+  alias <%= inspect context.module %>
+  alias <%= inspect schema.module %>
+  alias JaSerializer.Params
+
+  action_fallback <%= inspect context.web_module %>.FallbackController
+
+  def index(conn, _params) do
+    <%= schema.plural %> = <%= inspect context.alias %>.list_<%= schema.plural %>()
+    render(conn, "index.json-api", data: <%= schema.plural %>)
+  end
+
+  def create(conn, %{"data" => data = %{"type" => <%= inspect JaSerializer.Formatter.Utils.format_key(schema.singular) %>, "attributes" => <%= schema.singular %>_params}}) do
+    with {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} <- <%= inspect context.alias %>.create_<%= schema.singular %>(<%= schema.singular %>_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", <%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>))
+      |> render("show.json-api", data: <%= schema.singular %>)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>!(id)
+    render(conn, "show.json-api", data: <%= schema.singular %>)
+  end
+
+  def update(conn, %{"id" => id, "data" => data = %{"type" => <%= inspect JaSerializer.Formatter.Utils.format_key(schema.singular) %>, "attributes" => <%= schema.singular %>_params}}) do
+    <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>!(id)
+
+    with {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} <- <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, <%= schema.singular %>_params) do
+      render(conn, "show.json-api", data: <%= schema.singular %>)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>!(id)
+    with {:ok, %<%= inspect schema.alias %>{}} <- <%= inspect context.alias %>.delete_<%= schema.singular %>(<%= schema.singular %>) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/priv/templates/ja_serializer.gen.phx_api/controller_test.exs
+++ b/priv/templates/ja_serializer.gen.phx_api/controller_test.exs
@@ -15,7 +15,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   <%= if Enum.count(schema.assocs) != 0 do %>
   defp relationships do <%= for {ref, key, _, _} <- schema.assocs do %>
-    <%= ref %> = Repo.insert!(%<%= context.web_module %>.<%= Phoenix.Naming.camelize(ref) %>{})<% end %>
+    <%= ref %> = Repo.insert!(%<%= context.web_module %>.<%= Phoenix.Naming.camelize("#{ref}") %>{})<% end %>
 
     %{<%= for {ref, key, _, _} <- schema.assocs do %>
       "<%= ref %>" => %{

--- a/priv/templates/ja_serializer.gen.phx_api/controller_test.exs
+++ b/priv/templates/ja_serializer.gen.phx_api/controller_test.exs
@@ -14,8 +14,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   <%= if Enum.count(schema.assocs) != 0 do %>
-  defp relationships do <%= for {ref, key, _, _} <- schema.assocs do %>
-    <%= ref %> = Repo.insert!(%<%= context.web_module %>.<%= Phoenix.Naming.camelize("#{ref}") %>{})<% end %>
+  defp relationships do <%= for {ref, key, mod, _} <- schema.assocs do %>
+    <%= ref %> = Repo.insert!(%<%= mod %>{})<% end %>
 
     %{<%= for {ref, key, _, _} <- schema.assocs do %>
       "<%= ref %>" => %{

--- a/priv/templates/ja_serializer.gen.phx_api/controller_test.exs
+++ b/priv/templates/ja_serializer.gen.phx_api/controller_test.exs
@@ -1,0 +1,117 @@
+defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ControllerTest do
+  use <%= inspect context.web_module %>.ConnCase
+
+  alias <%= inspect context.module %>
+  alias <%= inspect schema.module %>
+
+  @create_attrs <%= inspect schema.params.create %>
+  @update_attrs <%= inspect schema.params.update %>
+  @invalid_attrs <%= inspect for {key, _} <- schema.params.create, into: %{}, do: {key, nil} %>
+
+  def fixture(:<%= schema.singular %>) do
+    {:ok, <%= schema.singular %>} = <%= inspect context.alias %>.create_<%= schema.singular %>(@create_attrs)
+    <%= schema.singular %>
+  end
+
+  <%= if Enum.count(schema.assocs) != 0 do %>
+  defp relationships do <%= for {ref, key, _, _} <- schema.assocs do %>
+    <%= ref %> = Repo.insert!(%<%= context.web_module %>.<%= Phoenix.Naming.camelize(ref) %>{})<% end %>
+
+    %{<%= for {ref, key, _, _} <- schema.assocs do %>
+      "<%= ref %>" => %{
+        "data" => %{
+          "type" => "<%= ref %>",
+          "id" => <%= ref %>.id
+        }
+      },<% end %>
+    }
+  end<% end %><%= if Enum.count(schema.assocs) == 0 do %>
+  defp relationships do
+    %{}
+  end<% end %>
+
+  setup %{conn: conn} do
+    conn = conn
+      |> put_req_header("accept", "application/vnd.api+json")
+      |> put_req_header("content-type", "application/vnd.api+json")
+      
+    {:ok, conn: conn}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, <%= schema.route_helper %>_path(conn, :index)
+    assert json_response(conn, 200)["data"] == []
+  end
+
+  test "creates <%= schema.singular %> and renders <%= schema.singular %> when data is valid", %{conn: conn} do
+    conn = post conn, <%= schema.route_helper %>_path(conn, :create), %{
+      "meta" => %{},
+      "data" => %{
+        "type" => "<%= JaSerializer.Formatter.Utils.format_key(schema.singular) %>",
+        "attributes" => @create_attrs,
+        "relationships" => relationships
+      }
+    }
+    assert %{"id" => id} = json_response(conn, 201)["data"]
+
+    conn = get conn, <%= schema.route_helper %>_path(conn, :show, id)
+    data = json_response(conn, 200)["data"]
+    assert data["id"] == id
+    assert data["type"] == "<%= JaSerializer.Formatter.Utils.format_key(schema.singular) %>"<%= for {k, _} <- schema.params.create do %>
+    assert data["attributes"]["<%= JaSerializer.Formatter.Utils.format_key(k) %>"] == @create_attrs.<%= k %><% end %>
+  end
+
+  test "does not create <%= schema.singular %> and renders errors when data is invalid", %{conn: conn} do
+    conn = post conn, <%= schema.route_helper %>_path(conn, :create), %{
+      "meta" => %{},
+      "data" => %{
+        "type" => "<%= JaSerializer.Formatter.Utils.format_key(schema.singular) %>",
+        "attributes" => @invalid_attrs,
+        "relationships" => relationships
+      }
+    }
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "updates chosen <%= schema.singular %> and renders <%= schema.singular %> when data is valid", %{conn: conn} do
+    %<%= inspect schema.alias %>{id: id} = <%= schema.singular %> = fixture(:<%= schema.singular %>)
+    conn = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), %{
+      "meta" => %{},
+      "data" => %{
+        "type" => "<%= JaSerializer.Formatter.Utils.format_key(schema.singular) %>",
+        "id" => "#{<%= schema.singular %>.id}",
+        "attributes" => @update_attrs,
+        "relationships" => relationships
+      }
+    }
+
+    conn = get conn, <%= schema.route_helper %>_path(conn, :show, id)
+    data = json_response(conn, 200)["data"]
+    assert data["id"] == "#{id}"
+    assert data["type"] == "<%= JaSerializer.Formatter.Utils.format_key(schema.singular) %>"<%= for {k, _} <- schema.params.create do %>
+    assert data["attributes"]["<%= JaSerializer.Formatter.Utils.format_key(k) %>"] == @update_attrs.<%= k %><% end %>
+  end
+
+  test "does not update chosen <%= schema.singular %> and renders errors when data is invalid", %{conn: conn} do
+    <%= schema.singular %> = fixture(:<%= schema.singular %>)
+    conn = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), %{
+      "meta" => %{},
+      "data" => %{
+        "type" => "<%= JaSerializer.Formatter.Utils.format_key(schema.singular) %>",
+        "id" => "#{<%= schema.singular %>.id}",
+        "attributes" => @invalid_attrs,
+        "relationships" => relationships
+      }
+    }
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "deletes chosen <%= schema.singular %>", %{conn: conn} do
+    <%= schema.singular %> = fixture(:<%= schema.singular %>)
+    conn = delete conn, <%= schema.route_helper %>_path(conn, :delete, <%= schema.singular %>)
+    assert response(conn, 204)
+    assert_error_sent 404, fn ->
+      get conn, <%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>)
+    end
+  end
+end

--- a/priv/templates/ja_serializer.gen.phx_api/view.ex
+++ b/priv/templates/ja_serializer.gen.phx_api/view.ex
@@ -1,0 +1,10 @@
+defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>View do
+  use <%= inspect context.web_module %>, :view
+  use JaSerializer.PhoenixView
+  
+  attributes [<%= (schema.types |> Enum.map(fn({k, v}) -> ":#{k}" end)) ++ [":inserted_at", ":updated_at"] |> Enum.join(", ") %>]
+  <%= for {ref, key, _, _} <- schema.assocs do %>
+  has_one :<%= ref %>,
+    field: :<%= key %>,
+    type: "<%= ref %>"<% end %>
+end


### PR DESCRIPTION
Provides generator task for phoenix 1.3  supporting context / schema instead of model.
`
mix ja_serializer.gen.phx_api Posts Comment comments name:string age:integer user_id:references:users
`

In addition, it applies the right key_format for the controller test
The controller test is based on the new controller test using fixtures