### PR TITLE
Perf improvement - Inline DSL attributes

### DIFF
--- a/bench/ja_serializer/phoenix_view_bench.exs
+++ b/bench/ja_serializer/phoenix_view_bench.exs
@@ -9,26 +9,44 @@ defmodule JaSerializer.PhoenixViewBench do
          |> Enum.map(&{String.to_atom("key_#{&1}"), &1})
          |> Enum.into(%{})
 
-  defmodule BenchView do
+  defmodule BenchSmallView do
     use JaSerializer.PhoenixView
 
-    attributes [:key_1, :key_2, :key_3, :key_4, :key_5]
+    attributes [:key_1,:key_2,:key_3,:key_4,:key_5]
+  end
+
+  defmodule BenchBigView do
+    use JaSerializer.PhoenixView
+
+    attributes [:key_1,:key_2,:key_3,:key_4,:key_5,
+                :key_6,:key_7,:key_8,:key_9,:key_10,
+                :key_11,:key_12,:key_13,:key_14,:key_15,
+                :key_16,:key_17,:key_18,:key_19,:key_20]
   end
 
   bench "attributes map small data",
     [context: @small],
-    do: BenchView.attributes(context, nil)
+    do: BenchSmallView.attributes(context, nil)
 
   bench "attributes map big data",
     [context: @big],
-    do: BenchView.attributes(context, nil)
+    do: BenchBigView.attributes(context, nil)
 
-  bench "render index small data",
+  bench "render index one item small data",
     [context: @small],
-    do: BenchView.render("index.json-api", data: context)
+    do: BenchSmallView.render("index.json-api", data: context)
 
-  bench "render index map big data",
+  bench "render index one item map big data",
     [context: @big],
-    do: BenchView.render("index.json-api", data: context)
+    do: BenchBigView.render("index.json-api", data: context)
+
+  bench "render index 25 items small data",
+    [context: 1..25 |> Enum.map(fn _ -> @small end) ],
+    do: BenchSmallView.render("index.json-api", data: context)
+
+  bench "render index 25 items map big data",
+    [context: 1..25 |> Enum.map(fn _ -> @big end)],
+    do: BenchBigView.render("index.json-api", data: context)
+
 
 end

--- a/bench/ja_serializer/phoenix_view_bench.exs
+++ b/bench/ja_serializer/phoenix_view_bench.exs
@@ -1,0 +1,34 @@
+defmodule JaSerializer.PhoenixViewBench do
+  use Benchfella
+
+  @big 1..20
+       |> Enum.map(&{String.to_atom("key_#{&1}"), &1})
+       |> Enum.into(%{})
+
+  @small 1..5
+         |> Enum.map(&{String.to_atom("key_#{&1}"), &1})
+         |> Enum.into(%{})
+
+  defmodule BenchView do
+    use JaSerializer.PhoenixView
+
+    attributes [:key_1, :key_2, :key_3, :key_4, :key_5]
+  end
+
+  bench "attributes map small data",
+    [context: @small],
+    do: BenchView.attributes(context, nil)
+
+  bench "attributes map big data",
+    [context: @big],
+    do: BenchView.attributes(context, nil)
+
+  bench "render index small data",
+    [context: @small],
+    do: BenchView.render("index.json-api", data: context)
+
+  bench "render index map big data",
+    [context: @big],
+    do: BenchView.render("index.json-api", data: context)
+
+end

--- a/lib/ja_serializer/dsl.ex
+++ b/lib/ja_serializer/dsl.ex
@@ -93,7 +93,7 @@ defmodule JaSerializer.DSL do
     }
 
     quote do
-      @compile {:inline, default_attributes: 2}
+      @compile {:inline, inlined_attributes_map: 2}
       def inlined_attributes_map(unquote(struct), unquote(conn)), do: unquote(body)
       defoverridable [attributes: 2]
     end

--- a/lib/ja_serializer/dsl.ex
+++ b/lib/ja_serializer/dsl.ex
@@ -72,28 +72,41 @@ defmodule JaSerializer.DSL do
   end
 
   @doc false
-  defmacro __before_compile__(_env) do
+  defmacro __before_compile__(env) do
     quote do
       def __relations,  do: @relations
       def __location,   do: @location
       def __attributes, do: @attributes
+
+      unquote(define_inlined_attributes_map(env))
+    end
+  end
+
+  defp define_inlined_attributes_map(env) do
+    attributes = Module.get_attribute(env.module, :attributes)
+    conn = quote do: conn
+    struct = quote do: struct
+
+    # Construct ASL for map with keys from attributes calling the attribute fn
+    body = {:%{}, [],
+      Enum.map(attributes, fn k -> {k, {k, [], [struct, conn]}} end)
+    }
+
+    quote do
+      @compile {:inline, default_attributes: 2}
+      def inlined_attributes_map(unquote(struct), unquote(conn)), do: unquote(body)
+      defoverridable [attributes: 2]
     end
   end
 
   defp define_default_attributes do
     quote do
+      @compile {:inline, attributes: 2}
       def attributes(struct, conn) do
-        JaSerializer.DSL.default_attributes(__MODULE__, struct, conn)
+        inlined_attributes_map(struct, conn)
       end
       defoverridable [attributes: 2]
     end
-  end
-
-  @doc false
-  def default_attributes(serializer, struct, conn) do
-    serializer.__attributes
-    |> Enum.map(&({&1, apply(serializer, &1, [struct, conn])}))
-    |> Enum.into(%{})
   end
 
   defp define_default_relationships do
@@ -217,15 +230,17 @@ defmodule JaSerializer.DSL do
   using super, or without the DSL just returning a map.
 
   """
-  defmacro attributes(atts) do
+  defmacro attributes(atts) when is_list(atts) do
     quote bind_quoted: [atts: atts] do
       # Save attributes
       @attributes @attributes ++ atts
 
       # Define default attribute function, make overridable
       for att <- atts do
+        @compile {:inline, [{att, 1}, {att, 2}]}
+
         def unquote(att)(m),    do: Map.get(m, unquote(att))
-        def unquote(att)(m, c), do: apply(__MODULE__, unquote(att), [m])
+        def unquote(att)(m, c), do: unquote(att)(m)
         defoverridable [{att, 2}, {att, 1}]
       end
     end

--- a/test/ja_serializer/serializer_test.exs
+++ b/test/ja_serializer/serializer_test.exs
@@ -3,7 +3,8 @@ defmodule JaSerializer.SerializerTest do
 
   defmodule ArticleSerializer do
     use JaSerializer
-    attributes [:title, :body]
+    attributes [:title]
+    attributes [:body]
     has_many :comments
   end
 


### PR DESCRIPTION
In our application we use `JaSerializer.PhoenixView` and we noticed rather poor performance when rendering lot of data with big models.

I did some `mix profiler.fprof` tracing and noticed there is lot of function calls caused by that each attribute in the serializer module genrated by DSL is a method call, which is even called twice to translate from `/2` to `/1` signature.

Even tho in the end it is all simple `Map.get` operations, the pure fact of invoking method calls have some overhead in Elixir's (resp. Erlang's) VM.

Here is a patch that using Elixir's macros generate attributes map compile time. On top of that I modified attributes macro to avoid `apply` and hence to make use of `@compile {:inline}` to inline each of the attribute methods during compile time as well. The result is that call to `attributes` doesn't have descendant method calls and instead the whole map construction is inlined.

I also added benchmark for those, here are results (MacBook Pro 2.7 GHz Intel Core i5):

`master (b5d9f1d)`:
```
$ mix bench bench/ja_serializer/phoenix_view_bench.exs
Settings:
  duration:      1.0 s

## JaSerializer.PhoenixViewBench
[18:55:24] 1/6: attributes map big data
[18:55:26] 2/6: attributes map small data
[18:55:33] 3/6: render index 25 items map big data
[18:55:36] 4/6: render index 25 items small data
[18:55:38] 5/6: render index one item map big data
[18:55:41] 6/6: render index one item small data

Finished in 19.17 seconds

## JaSerializer.PhoenixViewBench
attributes map small data             10000000   0.68 µs/op
attributes map big data                 500000   3.14 µs/op # <-- Notice difference on big data
render index one item small data        100000   18.64 µs/op
render index one item map big data       50000   41.41 µs/op
render index 25 items small data          5000   329.95 µs/op
render index 25 items map big data        2000   961.51 µs/op
```

`inline-dsl-attributes`:
```
$ mix bench bench/ja_serializer/phoenix_view_bench.exs
Settings:
  duration:      1.0 s

## JaSerializer.PhoenixViewBench
[18:57:02] 1/6: attributes map big data
[18:57:13] 2/6: attributes map small data
[18:57:16] 3/6: render index 25 items map big data
[18:57:18] 4/6: render index 25 items small data
[18:57:21] 5/6: render index one item map big data
[18:57:24] 6/6: render index one item small data

Finished in 23.11 seconds

## JaSerializer.PhoenixViewBench
attributes map small data             10000000   0.23 µs/op
attributes map big data               10000000   0.97 µs/op # <-- Notice difference on big data
render index one item small data        100000   17.17 µs/op
render index one item map big data       50000   38.33 µs/op
render index 25 items small data         10000   257.75 µs/op
render index 25 items map big data        2000   794.38 µs/op
```

As you can see there is definitive boost in the `attributes` function. The overall render is not much better, but it is still better.

There is definitely more room to go - inline other serialized fields like meta, id, ... - And perhaps then inline the whole data map for given object. Not sure how far this can be stretched before it is "needed" to go runtime.

Let me know what you think.