### PR TITLE
Merge links in correct order

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,12 +308,12 @@ and `last`.
 For example:
 
 ```elixir
-page = [
+page = %{
   first: "http://example.com/api/v1/posts?page[cursor]=1&page[per]=20",
   prev: nil
   next: "http://example.com/api/v1/posts?page[cursor]=20&page[per]=20",
   last: "http://example.com/api/v1/posts?page[cursor]=60&page[per]=20"
-]
+}
 
 # Direct call
 JaSerializer.format(MySerializer, collection, conn, page: page)

--- a/lib/ja_serializer/builder/top_level.ex
+++ b/lib/ja_serializer/builder/top_level.ex
@@ -12,7 +12,7 @@ defmodule JaSerializer.Builder.TopLevel do
       opts = Enum.into(opts, %{})
       # Build scrivener pagination links before we lose page object
       links = JaSerializer.Builder.ScrivenerLinks.build(context)
-      opts = Map.update(opts, :page, links, &(Map.merge(&1, links)))
+      opts = Map.update(opts, :page, links, &(Map.merge(links, &1)))
 
       # Extract entries from page object
       build(%{context | data: page.entries, opts: opts})


### PR DESCRIPTION
Page links are merged in correct order now.
Also fix readme typo.