### PR TITLE
Fix an edge case with pagination links

### DIFF
--- a/lib/ja_serializer/builder/pagination_links.ex
+++ b/lib/ja_serializer/builder/pagination_links.ex
@@ -74,10 +74,17 @@ defmodule JaSerializer.Builder.PaginationLinks do
   defp page_url(number, base, size, orginal_params) do
     params =
       orginal_params
-      |> Map.merge(%{page_key() => %{page_number_key() => number, page_size_key() => size}})
+      |> Map.merge(page_params(number, size))
       |> Plug.Conn.Query.encode
 
     "#{base}?#{params}"
+  end
+
+  defp page_params(number, size) do
+    case page_key() do
+      nil -> %{page_number_key() => number, page_size_key() => size}
+      key -> %{key => %{page_number_key() => number, page_size_key() => size}}
+    end
   end
 
   defp page_key do

--- a/test/ja_serializer/builder/pagination_links_test.exs
+++ b/test/ja_serializer/builder/pagination_links_test.exs
@@ -140,6 +140,22 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
     assert links[:first] == "/api/v2/posts?page[number]=1&page[size]=20"
   end
 
+  test "url opts override conn url, old page params ignored when page_key is nil" do
+    Application.put_env(:ja_serializer, :page_key, nil)
+
+    data = %{
+      number: 1,
+      size: 20,
+      total: 30,
+    }
+    conn = %Plug.Conn{
+      query_params: %{"number" => 4},
+    }
+    links = PaginationLinks.build(data, conn)
+
+    assert links[:self] == "?number=1&size=20"
+  end
+
   test "base_url can be configured globally" do
     Application.put_env(:ja_serializer, :page_base_url, "http://api.example.com")
 


### PR DESCRIPTION
* When page_key is nil and the conn query params has page information
  page_url  was not overriding the page params

  For example:

  original_params contains `%{"number" => 3}`

  `%{page_key() => %{page_number_key() => number, page_size_key() =>
  %size}}` evalutes to `%{nil => %{"number" => 1, "size" => 20}`

  So when merging original_params with the above the map ends up with

`%{"number" => 3, nil => %{"number" => 1, "size" => 20}}`

  And the Plug.Conn.Query.encode of that map evalutes to
  "number=1&size=20&number=3"