### PR TITLE
updated copy_from function from phoenix/v1.3.0-rc.2 version to phoeni…

### DIFF
--- a/lib/mix/tasks/ja_serializer.gen.phx_api.ex
+++ b/lib/mix/tasks/ja_serializer.gen.phx_api.ex
@@ -70,10 +70,10 @@ if Code.ensure_loaded?(Phoenix) and Code.ensure_loaded?(Mix.Phoenix.Context) do
 
     def copy_new_files(%Context{} = context, paths, binding) do
       files = files_to_be_generated(context)
-      Mix.Phoenix.copy_from paths, "priv/templates/phx.gen.json", "", binding, files
+      Mix.Phoenix.copy_from paths, "priv/templates/phx.gen.json", binding, files
 
       files = ja_serializer_files_to_be_generated(context)
-      Mix.Phoenix.copy_from paths, "priv/templates/ja_serializer.gen.phx_api", "", binding, files
+      Mix.Phoenix.copy_from paths, "priv/templates/ja_serializer.gen.phx_api", binding, files
 
       if context.generate?, do: Gen.Context.copy_new_files(context, paths, binding)
 


### PR DESCRIPTION
…x/v1.3.0-rc.3 version

The code was written at the time of phoenix 1.3.0 rc.2.  

This change will allow phoenix 1.3.0 rc3 and after to work.