### PR TITLE
Fix relationship key formatting for multiword relationship names

### DIFF
--- a/lib/ja_serializer/params.ex
+++ b/lib/ja_serializer/params.ex
@@ -1,4 +1,5 @@
 defmodule JaSerializer.Params do
+  import JaSerializer.ParamParser.Utils, only: [format_key: 1]
   @moduledoc """
   Functions to help when working with json api params.
   """
@@ -58,11 +59,11 @@ defmodule JaSerializer.Params do
   defp parse_relationships(%{"relationships" => rels}) do
     Enum.reduce rels, %{}, fn
       ({name, %{"data" => nil}}, rel) ->
-        Map.put(rel, "#{name}_id", nil)
+        Map.put(rel, format_key("#{name}_id"), nil)
       ({name, %{"data" => %{"id" => id}}}, rel) ->
-        Map.put(rel, "#{name}_id", id)
+        Map.put(rel, format_key("#{name}_id"), id)
       ({name, %{"data" => ids}}, rel) when is_list(ids) ->
-        Map.put(rel, "#{name}_ids", Enum.map(ids, &(&1["id"])))
+        Map.put(rel, format_key("#{name}_ids"), Enum.map(ids, &(&1["id"])))
     end
   end
 

--- a/test/ja_serializer/params_test.exs
+++ b/test/ja_serializer/params_test.exs
@@ -60,4 +60,19 @@ defmodule JaSerializer.ParamsTest do
     }
     assert to_attributes(input) == output
   end
+
+  test "double word relationships" do
+    input = %{"data" => %{
+      "type" => "person",
+      "attributes" => %{"first" => "Jane", "last" => "Doe", "type" => "anon"},
+      "relationships" => %{"user-account" => %{"data" => %{"id" => 1}}}
+    }}
+    output = %{
+      "first" => "Jane",
+      "last" => "Doe",
+      "type" => "anon",
+      "user_account_id" => 1
+    }
+    assert to_attributes(input) == output
+  end
 end


### PR DESCRIPTION
Currently any multi-word relationship names will end up formatted as `user-account_id` so this PR builds the id and then formats it.