### PR TITLE
Add identifiers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ list of relationships. Each relationship should be a dot separated path.
 Example: `include: "author,comments.author"`
 
 The format of this string should exactly match the one specified by the
-[JSON-API spec](http://jsonapi.org/format/#fetching-includes)
+[JSON-API spec](http://jsonapi.org/format/#fetching-includes).
 
 Note: If specifying the `include` option, all "default" includes will
 be ignored, and only the specified relationships included, per spec.
@@ -125,6 +125,21 @@ Example: `fields: %{"articles" => "title,body", "comments" => "body"}`
 
 If you're using Plug, you should be able to call `fetch_query_params(conn)`
 and pass the result of `conn.query_params["fields"]` as this option.
+
+#### Identifiers
+
+Specifying an `identifiers` option overrides the identifiers field, including
+identifiers for the relationships specified. This option should be a comma separated
+list of relationships. Each relationship should be a dot separated path.
+
+Example: `identifiers: "author,comments.author"`
+
+The format of this string should exactly match the one specified by the
+[JSON-API spec](http://jsonapi.org/format/#fetching-includes).
+
+Note: If `identifiers` is specified, the default `:when_included` or `:always`
+`identifiers` option for the given relationship is overridden. (This does _not_
+override all relationship options, only those for the provided identifiers.)
 
 ## Phoenix Usage
 

--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -43,6 +43,8 @@ defmodule JaSerializer.Builder.Relationship do
     do: true
   defp should_have_identifiers?(%{serializer: _s, identifiers: :always}, _c),
     do: true
+  defp should_have_identifiers?(%{serializer: _s, name: name}, %{opts: [identifiers: identifiers]}),
+    do: is_list(identifiers[name])
   defp should_have_identifiers?(%{serializer: _s, identifiers: :when_included, name: name, include: true}, context) do
     case context[:opts][:include] do
       nil  -> true

--- a/lib/ja_serializer/builder/top_level.ex
+++ b/lib/ja_serializer/builder/top_level.ex
@@ -55,9 +55,15 @@ defmodule JaSerializer.Builder.TopLevel do
 
   defp normalize_opts(opts) do
     opts = Enum.into(opts, %{})
-    case opts[:include] do
+
+    opts = case opts[:include] do
       nil -> opts
       includes -> Map.put(opts, :include, normalize_includes(includes))
+    end
+
+    case opts[:identifiers] do
+      nil -> opts
+      identifiers -> Map.put(opts, :identifiers, normalize_identifiers(identifiers))
     end
   end
 
@@ -66,6 +72,8 @@ defmodule JaSerializer.Builder.TopLevel do
     |> String.split(",")
     |> normalize_relationship_path_list
   end
+
+  defp normalize_identifiers(identifiers), do: normalize_includes(identifiers)
 
   defp normalize_relationship_path_list(paths), do:
     normalize_relationship_path_list(paths, [])

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -121,7 +121,18 @@ defmodule JaSerializer.Builder.RelationshipTest do
     assert [_ri1, _ri2, _ri3] = rel.data
   end
 
-  test "identifiers are included if the serializer is passed in & name is not in include parama & identifiers is always" do
+  test "identifiers are included if the serializer is passed in & name is in include param & identifiers is when_included" do
+    comments = %HasMany{
+      serializer: CommentSerializer,
+      data: [1,2,3],
+      identifiers: :when_included
+    }
+    context = %{conn: %{}, opts: [include: [comments: []]]}
+    rel = Relationship.build({:comments, comments}, context)
+    assert [_ri1, _ri2, _ri3] = rel.data
+  end
+
+  test "identifiers are included if the serializer is passed in & name is not in include param & identifiers is always" do
     comments = %HasMany{
       serializer: CommentSerializer,
       data: [1,2,3],

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -110,6 +110,17 @@ defmodule JaSerializer.Builder.RelationshipTest do
     assert [_ri1, _ri2, _ri3] = rel.data
   end
 
+  test "identifiers are included if serializer is passed in & name is in the identifiers param" do
+    comments = %HasMany{
+      serializer: CommentSerializer,
+      data: [1,2,3],
+      identifiers: :when_included # overridden
+    }
+    context = %{conn: %{}, opts: [identifiers: [comments: []]]}
+    rel = Relationship.build({:comments, comments}, context)
+    assert [_ri1, _ri2, _ri3] = rel.data
+  end
+
   test "identifiers are included if the serializer is passed in & name is not in include parama & identifiers is always" do
     comments = %HasMany{
       serializer: CommentSerializer,


### PR DESCRIPTION
Specifying an `identifiers` option overrides the identifiers field, including identifiers for the relationships specified, allowing the inclusion of specific relationship identifiers independent of what's included (with `:when_included`) and without need of always including identifiers (with `:always`).