### PR TITLE
Discard non-map items when building includes WIP

### DIFF
--- a/lib/ja_serializer/builder/included.ex
+++ b/lib/ja_serializer/builder/included.ex
@@ -36,6 +36,7 @@ defmodule JaSerializer.Builder.Included do
   end
 
   defp resource_objects_for(structs, conn, serializer, opts) do
+    structs = Enum.filter(structs, &is_map/1)    
     %{data: structs, conn: conn, serializer: serializer, opts: opts}
     |> ResourceObject.build
     |> List.wrap

--- a/lib/ja_serializer/relationship.ex
+++ b/lib/ja_serializer/relationship.ex
@@ -137,8 +137,10 @@ defmodule JaSerializer.Relationship do
   @doc false
   def default_function(name, opts) do
     quote bind_quoted: [name: name, opts: opts] do
-      def unquote(name)(struct, _conn) do
-        JaSerializer.Relationship.get_data(struct, unquote(name), unquote(opts))
+      unless Module.defines?(__MODULE__, {name, 2}, :def) do
+        def unquote(name)(struct, _conn) do
+          JaSerializer.Relationship.get_data(struct, unquote(name), unquote(opts))
+        end
       end
       defoverridable [{name, 2}]
     end


### PR DESCRIPTION
If we want to have the builder create a resource identifier for non-existent includes, we need to provide the ID of the non-existent item when we receive nil in our serialize. But `included.ex` relies on the relationships being maps. To fix this we filter any non-maps out which prevents them from appearing in the included json object, making the behavior the same as if it were not included at all.