### PR TITLE
Read key format config value at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,8 +415,6 @@ config :ja_serializer,
   key_format: {:custom, MyStringModule, :camelize, :underscore}
 ```
 
-If you've already compiled your code, be sure to run `mix deps.clean ja_serializer && mix deps.get`
-
 ### Custom Attribute Value Formatters
 
 When serializing attribute values more complex than string, numbers, atoms or

--- a/lib/ja_serializer/formatter/utils.ex
+++ b/lib/ja_serializer/formatter/utils.ex
@@ -27,8 +27,6 @@ defmodule JaSerializer.Formatter.Utils do
     |> Enum.into(%{})
   end
 
-  @key_formatter Application.get_env(:ja_serializer, :key_format, :dasherized)
-
   @doc false
   def deep_format_keys(map) when is_map(map) do
     Enum.reduce(map, %{}, &deep_format_key_value/2)
@@ -46,7 +44,13 @@ defmodule JaSerializer.Formatter.Utils do
 
   @doc false
   def format_key(k) when is_atom(k), do: k |> Atom.to_string() |> format_key
-  def format_key(key), do: do_format_key(key, @key_formatter)
+
+  def format_key(key),
+    do:
+      do_format_key(
+        key,
+        Application.get_env(:ja_serializer, :key_format, :dasherized)
+      )
 
   @doc false
   def do_format_key(key, :underscored), do: key
@@ -57,7 +61,12 @@ defmodule JaSerializer.Formatter.Utils do
     do: apply(module, fun, [key])
 
   @doc false
-  def format_type(string), do: do_format_type(string, @key_formatter)
+  def format_type(string),
+    do:
+      do_format_type(
+        string,
+        Application.get_env(:ja_serializer, :key_format, :dasherized)
+      )
 
   @doc false
   def do_format_type(string, :dasherized), do: dasherize(string)

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -415,24 +415,25 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     json =
       JaSerializer.format(ArticleSerializer, a1, %{},
-        include: "author.publishing-agent"
+        include: "author.publishing_agent"
       )
 
     ids = Enum.map(json["included"], &Map.get(&1, "id"))
-    refute "p1" in ids
+
+    assert "p1" in ids
 
     Application.put_env(
       :ja_serializer,
       :key_format,
-      {:custom, Macro, nil, :underscore}
+      {:custom, String, :capitalize, :downcase}
     )
 
     json =
       JaSerializer.format(ArticleSerializer, a1, %{},
-        include: "author.publishing-agent"
+        include: "Author.Publishing_agent"
       )
 
     ids = Enum.map(json["included"], &Map.get(&1, "id"))
-    refute "p1" in ids
+    assert "p1" in ids
   end
 end


### PR DESCRIPTION
Previously, the `:key_format` config value was read into a module attribute
`@key_formatter` in `JaSerializer.Formatter.Utils`.

It was therefore read from the config at compile-time and stored in the compiled
module.

This leads to two things:

1. Tests using `Application.put_env/3` don't work as expected
   The tests that use `Application.put_env/3` don't work as one might think they
   do, since while the `put_env` call does change the config value, it does not
   change the already compiled `@key_formatter` module attribute, which means
   that all the tests will keep using the default key formatting, regardless of
   the config value.

2. The library has to be recompiled after changing `key_format` config
   The library has to be recompiled at any time the `key_format` config key is
   changed, which has led to issues #63 and #261. #170, which was followed up by
   #172, fixes a similar issue.

I found [this article on erlang-solutions.com](https://www.erlang-solutions.com/blog/elixir-module-attributes-alchemy-101-part-1.html)
 that talks a bit more about module attributes and contains this nice piece of advice:

> The takeaway from this is: when using module attributes, always be aware of
> what they evaluate to, making a wrong assumption can result in having to
> recompile your project.

One other thing I fix here is that the custom key formatter set in one test in
included_tests.exs, `{:custom, Macro, nil, :underscore}` does not work, as it
ends up trying to call `Macro.nil`, which does not exist. Instead, I replaced
this with `{:custom, String, :capitalize, :downcase}` and changed any failing
tests accordingly.