### PR TITLE
Use `capture_io` in tests to make output less noisy

### DIFF
--- a/test/ja_serializer/dynamic_type_test.exs
+++ b/test/ja_serializer/dynamic_type_test.exs
@@ -1,6 +1,8 @@
 defmodule JaSerializer.DynamicTypeTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureIO
+
   @wilbur %{id: 1, name: "Wilbur", type: "pig"}
   @charlotte %{id: 1, name: "Charlotte", type: "spider"}
   @farm %{
@@ -9,6 +11,7 @@ defmodule JaSerializer.DynamicTypeTest do
     animals: [@wilbur, @charlotte],
     special_animal: @wilbur
   }
+  @expected_error "warning: returning an anonymous function from type/0 is deprecated. Please use the `type/2` callback instead."
 
   defmodule AnimalSerializer do
     use JaSerializer
@@ -24,29 +27,50 @@ defmodule JaSerializer.DynamicTypeTest do
   end
 
   test "dynamically assigns the type for single item" do
-    wilbur = JaSerializer.format(AnimalSerializer, @wilbur)
-    assert wilbur["data"]["type"] == "pig"
+    error_output =
+      capture_io(:stderr, fn ->
+        wilbur = JaSerializer.format(AnimalSerializer, @wilbur)
+        assert wilbur["data"]["type"] == "pig"
+      end)
+
+    error_output =~ @expected_error
   end
 
   test "works for multiple items" do
-    animals = JaSerializer.format(AnimalSerializer, [@wilbur, @charlotte])
-    assert animals["data"] |> Enum.map(& &1["type"]) == ~w(pig spider)
+    error_output =
+      capture_io(:stderr, fn ->
+        animals = JaSerializer.format(AnimalSerializer, [@wilbur, @charlotte])
+        assert animals["data"] |> Enum.map(& &1["type"]) == ~w(pig spider)
+      end)
+
+    assert error_output == ""
   end
 
   test "works with 'has_many' relationship data" do
-    farm = JaSerializer.format(FarmSerializer, @farm)
+    error_output =
+      capture_io(:stderr, fn ->
+        farm = JaSerializer.format(FarmSerializer, @farm)
 
-    animals =
-      farm["data"]["relationships"]["animals"]["data"] |> Enum.map(& &1["type"])
+        animals =
+          farm["data"]["relationships"]["animals"]["data"]
+          |> Enum.map(& &1["type"])
 
-    assert "pig" in animals
-    assert "spider" in animals
+        assert "pig" in animals
+        assert "spider" in animals
+      end)
+
+    assert error_output =~ @expected_error
   end
 
   test "works with 'has_one' relationship data" do
-    farm = JaSerializer.format(FarmSerializer, @farm)
+    error_output =
+      capture_io(:stderr, fn ->
+        farm = JaSerializer.format(FarmSerializer, @farm)
 
-    assert farm["data"]["relationships"]["special-animal"]["data"]["type"] ==
-             "pig"
+        assert farm["data"]["relationships"]["special-animal"]["data"]["type"] ==
+                 "pig"
+      end)
+
+    assert error_output =~ @expected_error
   end
 end

--- a/test/ja_serializer/dynamic_type_test.exs
+++ b/test/ja_serializer/dynamic_type_test.exs
@@ -33,7 +33,7 @@ defmodule JaSerializer.DynamicTypeTest do
         assert wilbur["data"]["type"] == "pig"
       end)
 
-    error_output =~ @expected_error
+    assert error_output == ""
   end
 
   test "works for multiple items" do

--- a/test/ja_serializer/phoenix_view_test.exs
+++ b/test/ja_serializer/phoenix_view_test.exs
@@ -1,6 +1,8 @@
 defmodule JaSerializer.PhoenixViewTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureIO
+
   defmodule PhoenixExample.ArticleView do
     use JaSerializer.PhoenixView
     attributes([:title])
@@ -28,17 +30,31 @@ defmodule JaSerializer.PhoenixViewTest do
 
   # This should be deprecated in the future
   test "render conn, index.json, data: data", c do
-    json = @view.render("index.json", conn: %{}, data: [c[:m1], c[:m2]])
-    assert [a1, _a2] = json["data"]
-    assert Map.has_key?(a1, "id")
-    assert Map.has_key?(a1, "attributes")
+    error_output =
+      capture_io(:stderr, fn ->
+        json = @view.render("index.json", conn: %{}, data: [c[:m1], c[:m2]])
+        assert [a1, _a2] = json["data"]
+        assert Map.has_key?(a1, "id")
+        assert Map.has_key?(a1, "attributes")
+      end)
+
+    assert error_output =~
+             "warning: Please use index.json-api instead. This will stop working in a future version."
   end
 
   test "render conn, index.json-api, articles: models", c do
-    json = @view.render("index.json-api", conn: %{}, articles: [c[:m1], c[:m2]])
-    assert [a1, _a2] = json["data"]
-    assert Map.has_key?(a1, "id")
-    assert Map.has_key?(a1, "attributes")
+    error_output =
+      capture_io(:stderr, fn ->
+        json =
+          @view.render("index.json-api", conn: %{}, articles: [c[:m1], c[:m2]])
+
+        assert [a1, _a2] = json["data"]
+        assert Map.has_key?(a1, "id")
+        assert Map.has_key?(a1, "attributes")
+      end)
+
+    assert error_output =~
+             "Passing data via `:model`, `:articles` or `:article`"
   end
 
   test "render conn, index.json-api, model: model with custom pagination", c do
@@ -94,15 +110,27 @@ defmodule JaSerializer.PhoenixViewTest do
 
   # This should be deprecated in the future
   test "render conn, show.json, data: model", c do
-    json = @view.render("show.json", conn: %{}, data: c[:m1])
-    assert Map.has_key?(json["data"], "id")
-    assert Map.has_key?(json["data"], "attributes")
+    error_output =
+      capture_io(:stderr, fn ->
+        json = @view.render("show.json", conn: %{}, data: c[:m1])
+        assert Map.has_key?(json["data"], "id")
+        assert Map.has_key?(json["data"], "attributes")
+      end)
+
+    assert error_output =~
+             "warning: Please use show.json-api instead. This will stop working in a future version.\n"
   end
 
   test "render conn, show.json-api, article: model", c do
-    json = @view.render("show.json-api", conn: %{}, article: c[:m1])
-    assert Map.has_key?(json["data"], "id")
-    assert Map.has_key?(json["data"], "attributes")
+    error_output =
+      capture_io(:stderr, fn ->
+        json = @view.render("show.json-api", conn: %{}, article: c[:m1])
+        assert Map.has_key?(json["data"], "id")
+        assert Map.has_key?(json["data"], "attributes")
+      end)
+
+    assert error_output =~
+             "Passing data via `:model`, `:articles` or `:article`"
   end
 
   test "render conn, 'errors.json-api', data: changeset" do
@@ -116,8 +144,16 @@ defmodule JaSerializer.PhoenixViewTest do
 
   # This should be deprecated in the future
   test "render conn, 'errors.json', data: changeset" do
-    errors = Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid")
-    json = @view.render("errors.json", conn: %{}, data: errors)
-    assert Map.has_key?(json, "errors")
+    error_output =
+      capture_io(:stderr, fn ->
+        errors =
+          Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid")
+
+        json = @view.render("errors.json", conn: %{}, data: errors)
+        assert Map.has_key?(json, "errors")
+      end)
+
+    assert error_output =~
+             "warning: Please use errors.json-api instead. This will stop working in a future version.\n"
   end
 end


### PR DESCRIPTION
These changes uses `ExUnit.CaptureIO` in tests for two purposes:

1. Make test output less noisy
2. Assert that messages are actually printed