### PR TITLE
Overridable render method

### DIFF
--- a/lib/ja_serializer/phoenix_view.ex
+++ b/lib/ja_serializer/phoenix_view.ex
@@ -82,6 +82,7 @@ defmodule JaSerializer.PhoenixView do
         JaSerializer.PhoenixView.render_errors(data)
       end
 
+      defoverridable render: 2
     end
   end
 

--- a/test/ja_serializer/phoenix_view_test.exs
+++ b/test/ja_serializer/phoenix_view_test.exs
@@ -5,6 +5,14 @@ defmodule JaSerializer.PhoenixViewTest do
     use JaSerializer.PhoenixView
     attributes [:title]
     location "/api/articles"
+
+    def render("override.json-api", _data) do
+      send(self(), :override)
+    end
+
+    def render(template, data) do
+      super(template, data)
+    end
   end
 
   @view PhoenixExample.ArticleView
@@ -100,6 +108,11 @@ defmodule JaSerializer.PhoenixViewTest do
     assert [e1] = json["errors"]
     assert e1.source.pointer == "/data/attributes/title"
     assert e1.detail == "Title is invalid"
+  end
+
+  test "allows override on render" do
+    @view.render("override.json-api", %{})
+    assert_received(:override)
   end
 
   # This should be deprecated in the future


### PR DESCRIPTION
Making the render method overridable allows modifying keys, values before it goes to the outside world. 

Fixes https://github.com/vt-elixir/ja_serializer/issues/290 