### PR TITLE
Handle the case where the end of a link is a URI fragment e.g. /foo#path

### DIFF
--- a/lib/ja_serializer/builder/link.ex
+++ b/lib/ja_serializer/builder/link.ex
@@ -29,21 +29,14 @@ defmodule JaSerializer.Builder.Link do
 
   defp path_for_context(context, path) do
     uri = URI.parse(path)
+    path = Map.put(uri, :path, replaced_path_for_context(context, uri.path))
 
-    path =
-      uri
-      |> Map.put(:path, replaced_path_for_context(context, uri.path))
-      |> Map.put(:query, replaced_path_for_context(context, uri.query))
-      |> URI.to_string()
-
-    # Remove trailing question mark if there is no query string.
-    # A query string itself can contain a trailing question mark so we only
-    # do this if URI did not parse out a query.
-    if nil == uri.query do
-      Regex.replace(~r/\?$/, path, "")
+    if uri.query do
+      Map.put(path, :query, replaced_path_for_context(context, uri.query))
     else
       path
     end
+    |> URI.to_string()
   end
 
   defp replaced_path_for_context(_context, nil), do: ""

--- a/test/ja_serializer/builder/link_test.exs
+++ b/test/ja_serializer/builder/link_test.exs
@@ -15,7 +15,7 @@ defmodule JaSerializer.Builder.LinkTest do
 
     has_many(:comments,
       serializer: JaSerializer.Builder.LinkTest.CommentSerializer,
-      link: "articles/:id/comments"
+      link: "articles/:id/comments#all"
     )
   end
 
@@ -58,6 +58,6 @@ defmodule JaSerializer.Builder.LinkTest do
       ]
     } = primary_resource
 
-    assert href == "articles/a1/comments"
+    assert href == "articles/a1/comments#all"
   end
 end


### PR DESCRIPTION
The existing code would add a random question mark '?' inbetween
producing "/foo?#path" this is unnecessary and should become
"/foo#path". Instead of using a regex to remove, lets just not set it on
the URI if the query parameter is nil.