### PR TITLE
Added missing @callback in Serializer

### DIFF
--- a/lib/ja_serializer/serializer.ex
+++ b/lib/ja_serializer/serializer.ex
@@ -70,7 +70,12 @@ defmodule JaSerializer.Serializer do
   To override simply define the type function:
 
       def type(_post,_conn), do: "category"
+
+  Or
+
+      def type, do: "category"
   """
+  @callback type() :: String.t
   @callback type(map, Plug.Conn.t) :: String.t
 
   @doc """


### PR DESCRIPTION
Added missing @callback for `type/0` in Serializer

When this callback is missing, the calling code can't mark the type/0 function as a behaviour implementation like so:

```elixir
@impl JaSerializer.Serializer
def type, do: "category"
```