### PR TITLE
Only include attributes key when there are attributes present

### DIFF
--- a/lib/ja_serializer/formatter/resource.ex
+++ b/lib/ja_serializer/formatter/resource.ex
@@ -6,12 +6,12 @@ defimpl JaSerializer.Formatter, for: JaSerializer.Builder.ResourceObject do
     links = Utils.array_to_hash(resource.links)
 
     json = %{
-      "id"         => to_string(resource.id),
-      "type"       => resource.type,
-      "attributes" => Utils.array_to_hash(resource.attributes),
+      "id" => to_string(resource.id),
+      "type" => resource.type
     }
 
     json
+    |> Utils.put_if_present("attributes", Utils.array_to_hash(resource.attributes))
     |> Utils.put_if_present("relationships", relationships)
     |> Utils.put_if_present("links", links)
     |> Utils.put_if_present("meta", JaSerializer.Formatter.format(resource.meta))

--- a/test/ja_serializer/builder/resource_object_test.exs
+++ b/test/ja_serializer/builder/resource_object_test.exs
@@ -8,6 +8,11 @@ defmodule JaSerializer.Builder.ResourceObjectTest do
     attributes [:title, :body]
   end
 
+  defmodule NoAttributesSerializer do
+    use JaSerializer
+    def type, do: "articles"
+  end
+
   test "single resource object built correctly" do
     a1 = %TestModel.Article{id: "a1", title: "a1", body: "a1"}
 
@@ -43,5 +48,15 @@ defmodule JaSerializer.Builder.ResourceObjectTest do
     fields = Map.keys(attributes)
     assert "title" in fields
     refute "body" in fields
+  end
+
+  test "no attributes defined -> no attributes key in output" do
+    a1 = %TestModel.Article{id: "a1", title: "a1", body: "a1"}
+
+    json = JaSerializer.format(ArticleSerializer, a1)
+    assert Map.has_key?(json["data"], "attributes")
+
+    json = JaSerializer.format(NoAttributesSerializer, a1)
+    refute Map.has_key?(json["data"], "attributes")
   end
 end


### PR DESCRIPTION
We had a schema validation error in our endpoint responses, because the Formatter added an `attributes` key to the response, but our resource doesn't have attributes (it only has relationships).