### PR TITLE
Consistent relation override

### DIFF
--- a/lib/ja_serializer/relationship.ex
+++ b/lib/ja_serializer/relationship.ex
@@ -137,10 +137,13 @@ defmodule JaSerializer.Relationship do
   @doc false
   def default_function(name, opts) do
     quote bind_quoted: [name: name, opts: opts] do
-      def unquote(name)(struct, _conn) do
+      def unquote(name)(struct) do
         JaSerializer.Relationship.get_data(struct, unquote(name), unquote(opts))
       end
-      defoverridable [{name, 2}]
+      def unquote(name)(struct, _conn) do
+        unquote(name)(struct)
+      end
+      defoverridable [{name, 1}, {name, 2}]
     end
   end
 

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -32,7 +32,12 @@ defmodule JaSerializer.Builder.RelationshipTest do
              ]
 
     has_one :baz, field: :baz_id, type: "baz"
+    has_one :qux, type: "qux"
+
     def bars(_,_), do: [1,2,3]
+
+    def qux(%{quxes: [qux | _]}), do: qux
+    def qux(_), do: nil
   end
 
   test "custom id def respected in relationship data" do
@@ -144,5 +149,11 @@ defmodule JaSerializer.Builder.RelationshipTest do
   test "skipping relationship building with `relationships: false`" do
     json = JaSerializer.format(FooSerializer, %{baz_id: 1, id: 1}, %{}, relationships: false)
     refute Map.has_key?(json["data"], "relationships")
+  end
+
+  test "can override default relationship function with one argument" do
+    json = JaSerializer.format(FooSerializer, %{quxes: [1, 2, 3]})
+    assert %{"relationships" => %{"qux" => qux}} = json["data"]
+    assert qux == %{"data" => %{"id" => "1", "type" => "qux"}}
   end
 end


### PR DESCRIPTION
Closes #298

For attributes it is possible to override function with either one or two arguments: `(model)` or `(model, conn)`.
For relations, only the `(model, conn)` override is possible. This is inconsistent and might confuse.

This PR adds the `(model)` override to relations too.