### PR TITLE
Fix compilation error when defining already inlined by compiler methods

### DIFF
--- a/lib/ja_serializer/builder/included.ex
+++ b/lib/ja_serializer/builder/included.ex
@@ -53,9 +53,12 @@ defmodule JaSerializer.Builder.Included do
     |> Enum.filter(fn {rel_name, rel_definition} ->
       case context[:opts][:include] do
         # if `include` param is not present only return 'default' includes
-        nil -> rel_definition.include == true
+        nil ->
+          rel_definition.include == true
+
         # otherwise only include requested includes
-        includes -> is_list(includes[rel_name])
+        includes ->
+          is_list(includes[rel_name])
       end
     end)
   end

--- a/lib/ja_serializer/dsl.ex
+++ b/lib/ja_serializer/dsl.ex
@@ -97,9 +97,13 @@ defmodule JaSerializer.DSL do
       @compile {:inline, inlined_attributes_map: 2}
       def inlined_attributes_map(unquote(struct), unquote(conn)) do
         # Construct ASL for map with keys from attributes calling the attribute fn
-        unquote({:%{}, [], Enum.map(attributes, fn k ->
-          {k, {{:., [], [{:__aliases__, [], [view]}, k]}, [], [struct, conn]}}
-        end)})
+        unquote(
+          {:%{}, [],
+           Enum.map(attributes, fn k ->
+             {k,
+              {{:., [], [{:__aliases__, [], [view]}, k]}, [], [struct, conn]}}
+           end)}
+        )
       end
 
       defoverridable attributes: 2

--- a/test/bench.exs
+++ b/test/bench.exs
@@ -13,7 +13,8 @@ defmodule BarSerializer do
 
   attributes([])
 
-  has_one(:foo,
+  has_one(
+    :foo,
     serializer: FooSerializer
   )
 end
@@ -25,7 +26,8 @@ defmodule FooSerializer do
 
   attributes([])
 
-  has_many(:bars,
+  has_many(
+    :bars,
     include: true,
     serializer: BarSerializer
   )

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -7,17 +7,20 @@ defmodule JaSerializer.Builder.IncludedTest do
     def type, do: "articles"
     attributes([:title])
 
-    has_many(:comments,
+    has_many(
+      :comments,
       serializer: JaSerializer.Builder.IncludedTest.CommentSerializer,
       include: true
     )
 
-    has_one(:author,
+    has_one(
+      :author,
       serializer: JaSerializer.Builder.IncludedTest.PersonSerializer,
       include: true
     )
 
-    has_many(:tags,
+    has_many(
+      :tags,
       serializer: JaSerializer.Builder.IncludedTest.TagSerializer
     )
   end
@@ -28,7 +31,8 @@ defmodule JaSerializer.Builder.IncludedTest do
     def type, do: "articles"
     attributes([:title])
 
-    has_many(:comments,
+    has_many(
+      :comments,
       include: JaSerializer.Builder.IncludedTest.CommentSerializer
     )
   end
@@ -39,17 +43,20 @@ defmodule JaSerializer.Builder.IncludedTest do
     def type, do: "articles"
     attributes([:title])
 
-    has_many(:comments,
+    has_many(
+      :comments,
       serializer: JaSerializer.Builder.IncludedTest.CommentSerializer,
       identifiers: :when_included
     )
 
-    has_one(:author,
+    has_one(
+      :author,
       serializer: JaSerializer.Builder.IncludedTest.PersonSerializer,
       identifiers: :when_included
     )
 
-    has_many(:tags,
+    has_many(
+      :tags,
       serializer: JaSerializer.Builder.IncludedTest.TagSerializer,
       identifiers: :always
     )
@@ -60,7 +67,8 @@ defmodule JaSerializer.Builder.IncludedTest do
     def type, do: "people"
     attributes([:first_name, :last_name])
 
-    has_one(:publishing_agent,
+    has_one(
+      :publishing_agent,
       serializer: JaSerializer.Builder.IncludedTest.PersonSerializer,
       include: false
     )
@@ -78,17 +86,20 @@ defmodule JaSerializer.Builder.IncludedTest do
     location("/comments/:id")
     attributes([:body])
 
-    has_one(:author,
+    has_one(
+      :author,
       serializer: JaSerializer.Builder.IncludedTest.PersonSerializer,
       include: true
     )
 
-    has_many(:comments,
+    has_many(
+      :comments,
       serializer: JaSerializer.Builder.IncludedTest.CommentSerializer,
       include: true
     )
 
-    has_many(:tags,
+    has_many(
+      :tags,
       serializer: JaSerializer.Builder.IncludedTest.TagSerializer
     )
   end
@@ -218,7 +229,10 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     # Formatted
     json =
-      JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{},
+      JaSerializer.format(
+        OptionalIncludeArticleSerializer,
+        a1,
+        %{},
         include: "author"
       )
 
@@ -265,7 +279,10 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     # Formatted
     json =
-      JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{},
+      JaSerializer.format(
+        OptionalIncludeArticleSerializer,
+        a1,
+        %{},
         include: "author,comments.author"
       )
 
@@ -308,7 +325,10 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     # Formatted
     json =
-      JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{},
+      JaSerializer.format(
+        OptionalIncludeArticleSerializer,
+        a1,
+        %{},
         include: "tags,comments.author,comments.tags"
       )
 
@@ -393,7 +413,10 @@ defmodule JaSerializer.Builder.IncludedTest do
     a1 = %TestModel.Article{id: "a1", title: "a1", author: p2, comments: [c1]}
 
     json =
-      JaSerializer.format(ArticleSerializer, a1, %{},
+      JaSerializer.format(
+        ArticleSerializer,
+        a1,
+        %{},
         include: "author.publishing-agent"
       )
 
@@ -404,7 +427,10 @@ defmodule JaSerializer.Builder.IncludedTest do
     Application.put_env(:ja_serializer, :key_format, :dasherized)
 
     json =
-      JaSerializer.format(ArticleSerializer, a1, %{},
+      JaSerializer.format(
+        ArticleSerializer,
+        a1,
+        %{},
         include: "author.publishing-agent"
       )
 
@@ -414,7 +440,10 @@ defmodule JaSerializer.Builder.IncludedTest do
     Application.put_env(:ja_serializer, :key_format, :underscored)
 
     json =
-      JaSerializer.format(ArticleSerializer, a1, %{},
+      JaSerializer.format(
+        ArticleSerializer,
+        a1,
+        %{},
         include: "author.publishing_agent"
       )
 
@@ -429,7 +458,10 @@ defmodule JaSerializer.Builder.IncludedTest do
     )
 
     json =
-      JaSerializer.format(ArticleSerializer, a1, %{},
+      JaSerializer.format(
+        ArticleSerializer,
+        a1,
+        %{},
         include: "Author.Publishing_agent"
       )
 

--- a/test/ja_serializer/builder/link_test.exs
+++ b/test/ja_serializer/builder/link_test.exs
@@ -4,7 +4,8 @@ defmodule JaSerializer.Builder.LinkTest do
   defmodule ArticleSerializer do
     use JaSerializer
 
-    has_many(:comments,
+    has_many(
+      :comments,
       serializer: JaSerializer.Builder.LinkTest.CommentSerializer,
       link: "comments?article_id=:id"
     )
@@ -13,7 +14,8 @@ defmodule JaSerializer.Builder.LinkTest do
   defmodule PostSerializer do
     use JaSerializer
 
-    has_many(:comments,
+    has_many(
+      :comments,
       serializer: JaSerializer.Builder.LinkTest.CommentSerializer,
       link: "articles/:id/comments#all"
     )

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -10,7 +10,8 @@ defmodule JaSerializer.Builder.RelationshipTest do
     def type, do: "articles"
     attributes([:title])
 
-    has_many(:comments,
+    has_many(
+      :comments,
       serializer: CommentSerializer,
       include: true
     )
@@ -27,7 +28,8 @@ defmodule JaSerializer.Builder.RelationshipTest do
   defmodule FooSerializer do
     use JaSerializer
 
-    has_many(:bars,
+    has_many(
+      :bars,
       type: "bar",
       links: [
         self: "/foo/:id/relationships/bars",
@@ -158,7 +160,10 @@ defmodule JaSerializer.Builder.RelationshipTest do
 
   test "skipping relationship building with `relationships: false`" do
     json =
-      JaSerializer.format(FooSerializer, %{baz_id: 1, id: 1}, %{},
+      JaSerializer.format(
+        FooSerializer,
+        %{baz_id: 1, id: 1},
+        %{},
         relationships: false
       )
 

--- a/test/ja_serializer/ecto_error_serializer_test.exs
+++ b/test/ja_serializer/ecto_error_serializer_test.exs
@@ -118,7 +118,10 @@ defmodule JaSerializer.EctoErrorSerializerTest do
 
     assert expected ==
              EctoErrorSerializer.format(
-               Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid",
+               Ecto.Changeset.add_error(
+                 %Ecto.Changeset{},
+                 :title,
+                 "is invalid",
                  type: {:array, :integer}
                )
              )

--- a/test/ja_serializer/json_api_spec/compound_document_test.exs
+++ b/test/ja_serializer/json_api_spec/compound_document_test.exs
@@ -94,25 +94,29 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
     location("/articles/:id")
     attributes([:title])
 
-    has_many(:comments,
+    has_many(
+      :comments,
       link: "/articles/:id/comments",
       serializer: CommentSerializer,
       include: true
     )
 
-    has_one(:author,
+    has_one(
+      :author,
       link: "/articles/:id/author",
       serializer: PersonSerializer,
       include: true
     )
 
-    has_many(:likes,
+    has_many(
+      :likes,
       link: "/articles/:id/likes",
       serializer: LikeSerializer,
       include: true
     )
 
-    has_one(:excerpt,
+    has_one(
+      :excerpt,
       link: "/articles/:id/excerpt",
       serializer: ExcerptSerializer,
       include: true

--- a/test/ja_serializer/json_api_spec/resource_object_test.exs
+++ b/test/ja_serializer/json_api_spec/resource_object_test.exs
@@ -43,20 +43,24 @@ defmodule JaSerializer.JsonApiSpec.ResourceObjectTest do
     def type, do: "articles"
     attributes([:title])
 
-    has_one(:author,
+    has_one(
+      :author,
       link: "/articles/:id/author",
       type: "people"
     )
 
-    has_many(:comments,
+    has_many(
+      :comments,
       link: "/articles/:id/comments"
     )
 
-    has_many(:likes,
+    has_many(
+      :likes,
       type: "like"
     )
 
-    has_one(:excerpt,
+    has_one(
+      :excerpt,
       type: "excerpt"
     )
 
@@ -104,7 +108,10 @@ defmodule JaSerializer.JsonApiSpec.ResourceObjectTest do
 
   test "it serializes properly using DSL", %{article: article} do
     results =
-      JaSerializer.format(ArticleSerializer, article, %{},
+      JaSerializer.format(
+        ArticleSerializer,
+        article,
+        %{},
         meta: %{copyright: 2015}
       )
       |> Poison.encode!()
@@ -115,7 +122,12 @@ defmodule JaSerializer.JsonApiSpec.ResourceObjectTest do
 
   test "it serializes properly using behaviour", %{article: article} do
     results =
-      JaSerializer.format(PostSerializer, article, %{}, meta: %{copyright: 2015})
+      JaSerializer.format(
+        PostSerializer,
+        article,
+        %{},
+        meta: %{copyright: 2015}
+      )
       |> Poison.encode!()
       |> Poison.decode!(keys: :atoms)
 

--- a/test/ja_serializer/phoenix_view_test.exs
+++ b/test/ja_serializer/phoenix_view_test.exs
@@ -59,7 +59,8 @@ defmodule JaSerializer.PhoenixViewTest do
 
   test "render conn, index.json-api, model: model with custom pagination", c do
     json =
-      @view.render("index.json-api",
+      @view.render(
+        "index.json-api",
         conn: %{},
         data: [c[:m1], c[:m2]],
         opts: [page: [first: "/v1/posts/foo"]]
@@ -74,7 +75,8 @@ defmodule JaSerializer.PhoenixViewTest do
   test "render conn, index.json-api, model: model with custom pagination using urls with ports",
        c do
     json =
-      @view.render("index.json-api",
+      @view.render(
+        "index.json-api",
         conn: %{},
         data: [c[:m1], c[:m2]],
         opts: [page: [first: "http://localhost:4000/v1/posts/foo"]]

--- a/test/ja_serializer/serializer_test.exs
+++ b/test/ja_serializer/serializer_test.exs
@@ -30,9 +30,19 @@ defmodule JaSerializer.SerializerTest do
     end
   end
 
+  defmodule InlineByCompilerArticle do
+    use JaSerializer
+
+    # Inline by compiler methods
+    attributes([:length, :pop_in, :raise])
+
+    def length(_article, _conn), do: 1
+  end
+
   @serializer ArticleSerializer
   @view ArticleView
   @custom CustomArticle
+  @inline_by_compiler InlineByCompilerArticle
 
   test "it should determine the type" do
     assert @serializer.type == "article"
@@ -50,6 +60,7 @@ defmodule JaSerializer.SerializerTest do
 
     assert @view.attributes(article, %{}) == %{title: "test"}
     assert @custom.attributes(article, %{}) == %{body: "test"}
+    assert @inline_by_compiler.attributes(article, %{}) == %{length: 1, pop_in: nil, raise: nil}
   end
 
   test "has_many should define an overridable relationship data function" do

--- a/test/ja_serializer/serializer_test.exs
+++ b/test/ja_serializer/serializer_test.exs
@@ -60,7 +60,12 @@ defmodule JaSerializer.SerializerTest do
 
     assert @view.attributes(article, %{}) == %{title: "test"}
     assert @custom.attributes(article, %{}) == %{body: "test"}
-    assert @inline_by_compiler.attributes(article, %{}) == %{length: 1, pop_in: nil, raise: nil}
+
+    assert @inline_by_compiler.attributes(article, %{}) == %{
+             length: 1,
+             pop_in: nil,
+             raise: nil
+           }
   end
 
   test "has_many should define an overridable relationship data function" do


### PR DESCRIPTION
Fixes https://github.com/vt-elixir/ja_serializer/issues/283
Related https://github.com/vt-elixir/ja_serializer/pull/245

Benchmark before the change:
```
Settings:
  duration:      1.0 s

## JaSerializer.PhoenixViewBench
[17:16:16] 1/6: attributes map big data
[17:16:21] 2/6: attributes map small data
[17:16:23] 3/6: render index 25 items map big data
[17:16:25] 4/6: render index 25 items small data
[17:16:29] 5/6: render index one item map big data
[17:16:32] 6/6: render index one item small data

Finished in 17.87 seconds

## JaSerializer.PhoenixViewBench
attributes map small data             10000000   0.12 µs/op
attributes map big data               10000000   0.46 µs/op
render index one item small data         20000   84.84 µs/op
render index one item map big data       20000   93.65 µs/op
render index 25 items small data         10000   292.75 µs/op
render index 25 items map big data        2000   820.56 µs/op
```

Benchmark after the change

```
Settings:
  duration:      1.0 s

## JaSerializer.PhoenixViewBench
[17:15:36] 1/6: attributes map big data
[17:15:42] 2/6: attributes map small data
[17:15:43] 3/6: render index 25 items map big data
[17:15:46] 4/6: render index 25 items small data
[17:15:48] 5/6: render index one item map big data
[17:15:50] 6/6: render index one item small data

Finished in 17.07 seconds

## JaSerializer.PhoenixViewBench
attributes map small data             10000000   0.13 µs/op
attributes map big data               10000000   0.53 µs/op
render index one item small data         20000   83.12 µs/op
render index one item map big data       20000   92.74 µs/op
render index 25 items small data          5000   288.62 µs/op
render index 25 items map big data        2000   785.51 µs/op
```

Best!