### PR TITLE
Restrict poison dep to only download for necessary envs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule JaSerializer.Mixfile do
     [
       {:inflex, "~> 1.4"},
       {:plug, "> 1.0.0"},
-      {:poison, ">= 1.4.0"},
+      {:poison, ">= 1.4.0", only: [:docs, :test]},
       {:ecto, "~> 1.1 or ~> 2.0", only: :test},
       {:earmark, "~> 0.1", only: :dev},
       {:inch_ex, "~> 0.4", only: :docs},


### PR DESCRIPTION
The Poison library is only needed for tests and doc generation, not for using the library in production. Not restricting this dep to these envs creates an unneeded dependency and download for users. This PR restricts the dep to the envs it is needed in.

Resolves #306