### PR TITLE
Use extra_applications over applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule JaSerializer.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:logger, :inflex, :plug, :poison]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do


### PR DESCRIPTION
Closes #309 

This will not attempt to start poison app when in a non-test environment.
Otherwise, poison is needed to use ja_serializer as a dependency.