### PR TITLE
Don't render empty relationships

### DIFF
--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -10,8 +10,12 @@ defmodule JaSerializer.Builder.Relationship do
         %{serializer: serializer, data: data, conn: conn, opts: opts} = context
       ) do
     case opts[:relationships] do
-      false -> []
-      _ -> Enum.map(serializer.relationships(data, conn), &build(&1, context))
+      false ->
+        []
+
+      _ ->
+        Enum.map(serializer.relationships(data, conn), &build(&1, context))
+        |> Enum.filter(fn r -> not empty?(r) end)
     end
   end
 
@@ -22,6 +26,9 @@ defmodule JaSerializer.Builder.Relationship do
     |> add_links(definition, context)
     |> add_data(definition, context)
   end
+
+  defp empty?(%__MODULE__{data: nil, links: nil, meta: nil}), do: true
+  defp empty?(%__MODULE__{} = _relationship), do: false
 
   defp add_links(relation, definition, context) do
     definition.links

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -25,6 +25,21 @@ defmodule JaSerializer.Builder.RelationshipTest do
     attributes([:body])
   end
 
+  defmodule CommentWithArticleSerializer do
+    use JaSerializer
+    def id(comment, _conn), do: comment.comment_id
+    def type, do: "comments"
+    location("/comments/:id")
+    attributes([:body])
+
+    has_one(
+      :article,
+      serializer: ArticleSerializer,
+      include: false,
+      identifiers: :when_included
+    )
+  end
+
   defmodule FooSerializer do
     use JaSerializer
 
@@ -174,5 +189,16 @@ defmodule JaSerializer.Builder.RelationshipTest do
     json = JaSerializer.format(FooSerializer, %{quxes: [1, 2, 3]})
     assert %{"relationships" => %{"qux" => qux}} = json["data"]
     assert qux == %{"data" => %{"id" => "1", "type" => "qux"}}
+  end
+
+  test "empty relationships are not included" do
+    json =
+      JaSerializer.format(
+        CommentWithArticleSerializer,
+        %{comment_id: 1, article: %{title: "title"}},
+        %{}
+      )
+
+    refute Map.has_key?(json["data"], "relationships")
   end
 end


### PR DESCRIPTION
This PR is a fix for #232, based on #235 but based on a new master and with an added test.

With this change, a relationship with no information will not be rendered