### PR TITLE
Omit prev/next links when higher than total page number

### DIFF
--- a/lib/ja_serializer/builder/pagination_links.ex
+++ b/lib/ja_serializer/builder/pagination_links.ex
@@ -76,6 +76,13 @@ defmodule JaSerializer.Builder.PaginationLinks do
   defp links(%{number: total, total: total}),
     do: [self: total, first: @page_number_origin, prev: total - 1]
 
+  defp links(%{number: number, total: total}) when number > total,
+    do: [
+      self: number,
+      first: @page_number_origin,
+      last: total
+    ]
+
   defp links(%{number: number, total: total}),
     do: [
       self: number,

--- a/test/ja_serializer/builder/pagination_links_test.exs
+++ b/test/ja_serializer/builder/pagination_links_test.exs
@@ -118,6 +118,24 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
     assert Enum.sort([:self]) == links
   end
 
+  test "when page number is above total, do not include prev, next links" do
+    data = %{
+      number: 16,
+      size: 20,
+      total: 15
+    }
+
+    conn = %Plug.Conn{query_params: %{}}
+
+    links =
+      data
+      |> PaginationLinks.build(conn)
+      |> Map.keys()
+      |> Enum.sort()
+
+    assert Enum.sort([:self, :first, :last]) == links
+  end
+
   test "url is taken from current conn url, params forwarded" do
     data = %{
       number: 30,


### PR DESCRIPTION
This makes the result to follow the specification instead of showing links that cannot exist.

Fixes #314