### PR TITLE
Add missing camel_cased for do_format_type

### DIFF
--- a/lib/ja_serializer/formatter/utils.ex
+++ b/lib/ja_serializer/formatter/utils.ex
@@ -78,6 +78,7 @@ defmodule JaSerializer.Formatter.Utils do
   @doc false
   def do_format_type(string, :dasherized), do: dasherize(string)
   def do_format_type(string, :underscored), do: underscore(string)
+  def do_format_type(string, :camel_cased), do: Inflex.camelize(string, :lower)
 
   def do_format_type(string, {:custom, module, fun}),
     do: apply(module, fun, [string])

--- a/test/ja_serializer/formatter/utils_test.exs
+++ b/test/ja_serializer/formatter/utils_test.exs
@@ -63,6 +63,11 @@ defmodule JaSerializer.Formatter.UtilsTest do
              "approved_comments"
   end
 
+  test "formatting type - camel_cased" do
+    assert Utils.do_format_type("ApprovedComments", :camel_cased) ==
+             "approvedComments"
+  end
+
   test "formatting type - custom" do
     custom = {:custom, JaSerializer.Formatter.UtilsTest, :smasherize, nil}
 


### PR DESCRIPTION
Apparently I missed the `do_format_type` method which would also need the `camel_cased` handling. This fixes it.