### PR TITLE
Allow accept header with quality param

### DIFF
--- a/lib/ja_serializer/content_type_negotiation.ex
+++ b/lib/ja_serializer/content_type_negotiation.ex
@@ -45,6 +45,7 @@ defmodule JaSerializer.ContentTypeNegotiation do
       conn
       |> get_req_header("accept")
       |> Enum.flat_map(&String.split(&1, ","))
+      |> Enum.map(&(&1 |> String.split(";") |> hd()))
       |> Enum.map(&string_trim/1)
 
     cond do

--- a/test/ja_serializer/content_type_negotiation_test.exs
+++ b/test/ja_serializer/content_type_negotiation_test.exs
@@ -78,10 +78,10 @@ defmodule JaSerializer.ContentTypeNegotiationTest do
     assert result.status == 415
   end
 
-  test "Returns 406 Not Acceptable if all media type params" do
+  test "Returns 406 Not Acceptable on non-jsonapi Accept header" do
     conn =
       Plug.Test.conn("GET", "/", %{})
-      |> put_req_header("accept", @invalid)
+      |> put_req_header("accept", "text/html")
 
     result = ExamplePlug.call(conn, [])
     assert result.status == 406
@@ -94,5 +94,16 @@ defmodule JaSerializer.ContentTypeNegotiationTest do
 
     result = ExamplePlug.call(conn, [])
     assert [@valid] = get_resp_header(result, "content-type")
+  end
+
+  test "accepts accept-header with quality" do
+    conn =
+      Plug.Test.conn("POST", "/", %{})
+      |> put_req_header("content-type", @valid)
+      |> put_req_header("accept", "text/html,*/*;q=0.9;")
+
+    result = ExamplePlug.call(conn, [])
+    assert result.status == 200
+    assert result.resp_body == "success"
   end
 end


### PR DESCRIPTION
Related to #138

When requesting with an Accept header with a quality param, e.g. `*/*;q=0.9`, a 406 would be returned.

The quality should be used to prioritize the caller's different acceptable response content-types, but since we only care about jsonapi content type, we should just ignore it.

~~I also removed a test for Accept header `application/vnd.api+json; charset=utf-8`, since `charset` is not a valid param to Accept headers.~~

I found this when requesting a ja_serializer endpoint with Chrome. Chrome sends by default this accept header:

```
text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3
```

Which should be accepted by ja_serializer because of the `*/*;q=0.8` part.

~~(The changes looks a bit weird in the github diff editor since I removed one test and added another. [This](https://github.com/lasseebert/ja_serializer/blob/f8cded6d667a8b59467df10e52e6b5e6a8390c20/test/ja_serializer/content_type_negotiation_test.exs#L90-L99) is the test I added)~~