### PR TITLE
Improves DSL for belongs to relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,28 @@
 
 ## Unreleased
 
+### Features
+  * Add optional support for camelCase key format as recommended by
+    JSON:API v1.1 - #316/#317
+
+### Bug fixes
+  * Allow accept header with quality param - #320
+
 ### Breaking
   * Don't render empty relationships - #311
   * Omit prev/next links when current page is > last page - #317
+  * Don't raise AssociationNotLoadedError if belongs to relationship can
+    be determined. - #322
+
+The following workaround is no longer needed:
+
+```
+has_one :city, serializer: MyApp.CityView
+
+def city(%{city: %Ecto.Association.NotLoaded{}, city_id: nil}, _conn), do: nil
+def city(%{city: %Ecto.Association.NotLoaded{}, city_id: id}, _conn), do: %{id: id}
+def city(%{city: city}, _conn), do: city
+```
 
 ## v0.14.1
 

--- a/lib/ja_serializer/dsl.ex
+++ b/lib/ja_serializer/dsl.ex
@@ -414,7 +414,25 @@ defmodule JaSerializer.DSL do
   @doc """
   See documentation for <a href='#has_many/2'>has_many/2</a>.
 
-  API is the exact same.
+  API is the exact same with one exception:
+
+  In the case of a belongs to relationship, JaSerializer will attempt to work
+  out the resource identifier when the relationship is not included/preloaded.
+  This reduces the amount of boiler plate code needed when relationship inclusion
+  is specified by the client (as opposed to using `include: true` in the serializer).
+
+  By default, JaSerializer appends `_id` to the resource name, but this can be
+  overridden with the `foreign_key` option.
+
+  In the following example, the user and author identifiers will be serialized
+  even if those relationships are not preloaded.
+
+      defmodule MyApp.PostView do
+        use JaSerializer
+
+        has_one :user, identifiers: :always, serializer: MyApp.UserView
+        has_one :author, identifiers: :always, foreign_key: :user_id, serializer: MyApp.UserView
+      end
   """
   defmacro has_one(name, opts \\ []) do
     normalized_opts = normalize_relation_opts(opts, __CALLER__)

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule JaSerializer.Mixfile do
   defp package do
     [
       licenses: ["Apache 2.0"],
-      maintainers: ["Alan Peabody"],
+      maintainers: ["Alan Peabody", "Peter Brown"],
       links: %{
         "GitHub" => "https://github.com/vt-elixir/ja_serializer"
       }


### PR DESCRIPTION
Previously when a belongs to relationship was not included, we were
raising an exception. Instead we can respond with the identifiers since
it doesn't require any additional data loading for this.

Closes #267 