### PR TITLE
Make normalize_includes public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
   * Add optional support for camelCase key format as recommended by
     JSON:API v1.1 - #316/#317
+  * Make JaSerializer.TopLevel.Builder.normalize_includes/1 public
 
 ### Bug fixes
   * Allow accept header with quality param - #320

--- a/lib/ja_serializer/builder/top_level.ex
+++ b/lib/ja_serializer/builder/top_level.ex
@@ -4,6 +4,7 @@ defmodule JaSerializer.Builder.TopLevel do
   alias JaSerializer.Builder.ResourceObject
   alias JaSerializer.Builder.Included
   alias JaSerializer.Builder.Link
+  alias JaSerializer.Builder.Utils
 
   defstruct [:data, :errors, :included, :meta, {:links, []}, :jsonapi]
 
@@ -65,47 +66,9 @@ defmodule JaSerializer.Builder.TopLevel do
 
     case opts[:include] do
       nil -> opts
-      includes -> Map.put(opts, :include, normalize_includes(includes))
+      includes -> Map.put(opts, :include, Utils.normalize_includes(includes))
     end
   end
-
-  defp normalize_includes(includes) do
-    includes
-    |> String.split(",")
-    |> normalize_relationship_path_list
-  end
-
-  defp normalize_relationship_path_list(paths),
-    do: normalize_relationship_path_list(paths, [])
-
-  defp normalize_relationship_path_list([], normalized), do: normalized
-
-  defp normalize_relationship_path_list([path | paths], normalized) do
-    normalized =
-      path
-      |> String.split(".")
-      |> Enum.map(&JaSerializer.ParamParser.Utils.format_key/1)
-      |> normalize_relationship_path
-      |> deep_merge_relationship_paths(normalized)
-
-    normalize_relationship_path_list(paths, normalized)
-  end
-
-  defp normalize_relationship_path([]), do: []
-
-  defp normalize_relationship_path([rel_name | remaining]) do
-    Keyword.put(
-      [],
-      String.to_atom(rel_name),
-      normalize_relationship_path(remaining)
-    )
-  end
-
-  defp deep_merge_relationship_paths(left, right),
-    do: Keyword.merge(left, right, &deep_merge_relationship_paths/3)
-
-  defp deep_merge_relationship_paths(_key, left, right),
-    do: deep_merge_relationship_paths(left, right)
 
   defp add_meta(tl, nil), do: tl
   defp add_meta(tl, %{} = meta), do: Map.put(tl, :meta, meta)

--- a/lib/ja_serializer/builder/utils.ex
+++ b/lib/ja_serializer/builder/utils.ex
@@ -1,0 +1,46 @@
+defmodule JaSerializer.Builder.Utils do
+  @moduledoc """
+  Utilities to work with building serialized data
+  """
+
+  def normalize_includes(nil), do: []
+  def normalize_includes(""), do: []
+
+  def normalize_includes(includes) do
+    includes
+    |> String.split(",")
+    |> normalize_relationship_path_list
+  end
+
+  defp normalize_relationship_path_list(paths),
+    do: normalize_relationship_path_list(paths, [])
+
+  defp normalize_relationship_path_list([], normalized), do: normalized
+
+  defp normalize_relationship_path_list([path | paths], normalized) do
+    normalized =
+      path
+      |> String.split(".")
+      |> Enum.map(&JaSerializer.ParamParser.Utils.format_key/1)
+      |> normalize_relationship_path
+      |> deep_merge_relationship_paths(normalized)
+
+    normalize_relationship_path_list(paths, normalized)
+  end
+
+  defp normalize_relationship_path([]), do: []
+
+  defp normalize_relationship_path([rel_name | remaining]) do
+    Keyword.put(
+      [],
+      String.to_atom(rel_name),
+      normalize_relationship_path(remaining)
+    )
+  end
+
+  defp deep_merge_relationship_paths(left, right),
+    do: Keyword.merge(left, right, &deep_merge_relationship_paths/3)
+
+  defp deep_merge_relationship_paths(_key, left, right),
+    do: deep_merge_relationship_paths(left, right)
+end

--- a/test/ja_serializer/builder/utils_test.exs
+++ b/test/ja_serializer/builder/utils_test.exs
@@ -1,0 +1,29 @@
+defmodule JaSerializer.Builder.UtilsTest do
+  use ExUnit.Case
+  alias JaSerializer.Builder.Utils
+
+  test "no includes" do
+    assert Utils.normalize_includes(nil) == []
+    assert Utils.normalize_includes("") == []
+  end
+
+  test "shallow includes" do
+    include = "include-one,include-two,three,four"
+
+    assert Utils.normalize_includes(include) == [
+             four: [],
+             three: [],
+             include_two: [],
+             include_one: []
+           ]
+  end
+
+  test "nested includes" do
+    include =
+      "include-one,include-one.include-two,include-one.include-two.include-three"
+
+    assert Utils.normalize_includes(include) == [
+             include_one: [include_two: [include_three: []]]
+           ]
+  end
+end


### PR DESCRIPTION
This function is useful for converting included params from the client
into Ecto's `preload/3` function.

Closes https://github.com/vt-elixir/ja_serializer/issues/284