### PR TITLE
Export `locals_without_parens` configuration on `formatter.exs`

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,10 @@
+locals_without_parens = [attributes: 1, location: 1, has_many: 2, has_one: 2]
+
 [
   inputs: ["*.{ex,exs}", "{bench,lib,test}/**/*.{ex,exs}"],
-  line_length: 80
+  line_length: 80,
+  locals_without_parens: locals_without_parens,
+  export: [
+    locals_without_parens: locals_without_parens
+  ]
 ]


### PR DESCRIPTION
Export formatter configuration to allow clients import it as formatting options on their own `formatter.exs` file. This is a similar approach to what [ecto](https://github.com/elixir-ecto/ecto/blob/master/.formatter.exs) and [phoenix](https://github.com/phoenixframework/phoenix/blob/master/.formatter.exs) apply on their formatter files.

Library clients can inherit this configuration by adding the library name in the `import_deps` option which will automatically inherit configurations that are defined inside the library `export` option.

For more information, check [mix format docs](https://hexdocs.pm/mix/Mix.Tasks.Format.html#module-importing-dependencies-configuration) and [Code.format_string/2](https://hexdocs.pm/elixir/Code.html#format_string!/2).