### PR TITLE
Allows import to be used as a relationship name

### DIFF
--- a/lib/ja_serializer/relationship.ex
+++ b/lib/ja_serializer/relationship.ex
@@ -139,7 +139,7 @@ defmodule JaSerializer.Relationship do
       end
 
       def unquote(name)(struct, _conn) do
-        unquote(name)(struct)
+        __MODULE__.unquote(name)(struct)
       end
 
       defoverridable [{name, 1}, {name, 2}]

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -17,6 +17,16 @@ defmodule JaSerializer.Builder.RelationshipTest do
     )
   end
 
+  defmodule ImportSerializer do
+    use JaSerializer
+    def type, do: "imports"
+  end
+
+  defmodule HasImport do
+    use JaSerializer
+    has_one(:import, serializer: ImportSerializer)
+  end
+
   defmodule CommentSerializer do
     use JaSerializer
     def id(comment, _conn), do: comment.comment_id
@@ -282,5 +292,11 @@ defmodule JaSerializer.Builder.RelationshipTest do
         %{}
       )
     end
+  end
+
+  test "serializer with Elixir keyword (import) as a relation name" do
+    json = JaSerializer.format(HasImport, %{import: %{id: 27}})
+    the_import = get_in(json, ["data", "relationships", "import"])
+    assert the_import == %{"data" => %{"id" => "27", "type" => "imports"}}
   end
 end


### PR DESCRIPTION
If one of your entities has a relationship called "import", and you are trying to upgrade `ja_serializer` then compilation fails with something like

```
invalid argument for import, expected a compile time atom or alias, got: struct
```

This is a fix for that.