### PR TITLE
Fixes broken links with has_one relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Breaking
+  * Empty relationships with links are now handled properly. Instead of
+    returning a relationship resource with a broken link, we now remove the
+    empty relationship from the serialized "relationships" key. This makes the
+    empty relationship behavior consistent with relationships that do not have
+    links.
+
 ## v0.16.0
 
 ### Breaking

--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -56,6 +56,7 @@ defmodule JaSerializer.Builder.Relationship do
     do: do_filter(relationships, Utils.safe_atom_list(fields))
 
   defp empty?(%__MODULE__{data: nil, links: nil, meta: nil}), do: true
+  defp empty?(%__MODULE__{data: :empty_relationship}), do: true
   defp empty?(%__MODULE__{} = _relationship), do: false
 
   defp add_links(relation, definition, context) do

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -61,6 +61,52 @@ defmodule JaSerializer.Builder.RelationshipTest do
     )
   end
 
+  defmodule Article do
+    defstruct article_id: nil, other_article_id: nil
+  end
+
+  defmodule CommentWithoutArticleSerializer do
+    use JaSerializer
+
+    has_one :article,
+      field: :article_id,
+      type: "article",
+      links: [
+        related: "/articles/:article_id"
+      ]
+
+    has_one :other_article,
+      field: :other_article_id,
+      type: "article",
+      links: [
+        related: "/articles/:other_article_id"
+      ]
+
+    def article(%{article_id: nil}, _conn) do
+      nil
+    end
+
+    def article(%{article_id: article_id}, _conn) do
+      %{id: article_id}
+    end
+
+    def other_article(%{other_article_id: nil}, _conn) do
+      nil
+    end
+
+    def other_article(%{other_article_id: article_id}, _conn) do
+      %{id: article_id}
+    end
+
+    def article_id(struct, _conn) do
+      struct.article_id
+    end
+
+    def other_article_id(struct, _conn) do
+      struct.other_article_id
+    end
+  end
+
   defmodule CommentWithArticlesForeignKeySerializer do
     use JaSerializer
 
@@ -243,6 +289,29 @@ defmodule JaSerializer.Builder.RelationshipTest do
       )
 
     refute Map.has_key?(json["data"], "relationships")
+  end
+
+  test "empty has_one relationships with links are not included" do
+    json =
+      JaSerializer.format(
+        CommentWithoutArticleSerializer,
+        %{article_id: nil},
+        %{}
+      )
+
+    refute Map.has_key?(json["data"], "relationships")
+  end
+
+  test "empty has_one relationships with links are not included with other relationships" do
+    %{"data" => %{"relationships" => relationships}} =
+      JaSerializer.format(
+        CommentWithoutArticleSerializer,
+        %{article_id: nil, other_article_id: 5},
+        %{}
+      )
+
+    assert Map.has_key?(relationships, "other-article")
+    refute Map.has_key?(relationships, "article")
   end
 
   test "has_one identifiers are serialized when present" do


### PR DESCRIPTION
This fixes an issue where we were serializing broken links for null
has_one relationships if the has_one relationship in the serializer
specified links. It is now consistent with other relationships where
links are not specified.