### PR TITLE
Fixes broken links with has_one relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Breaking
+  * Empty relationships with links are now handled properly. Instead of
+    returning a relationship resource with a broken link, we now remove the
+    broken links from the serialized "relationships" key.
+
 ## v0.16.0
 
 ### Breaking

--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -61,6 +61,10 @@ defmodule JaSerializer.Builder.Relationship do
   defp add_links(relation, definition, context) do
     definition.links
     |> Enum.map(fn {key, path} -> Link.build(context, key, path) end)
+    |> Enum.reject(fn
+      %{href: nil} -> true
+      _ -> false
+    end)
     |> case do
       [] -> relation
       links -> Map.put(relation, :links, links)


### PR DESCRIPTION
This fixes an issue where we were serializing broken links for null
has_one relationships if the has_one relationship in the serializer
specified links.