### PR TITLE
Use correct SPDX ID for licenses field

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule JaSerializer.Mixfile do
 
   defp package do
     [
-      licenses: ["Apache 2.0"],
+      licenses: ["Apache-2.0"],
       maintainers: ["Alan Peabody", "Peter Brown"],
       links: %{
         "GitHub" => "https://github.com/vt-elixir/ja_serializer"


### PR DESCRIPTION
The "Apache License 2.0" has the SPDX ID "Apache-2.0", according to the list at https://spdx.org/licenses/. While the string "Apache 2.0" is fully readable for humans, some tools use these fields to verify what licenses are used, and the tools tend to not be as flexible when reading strings that are interpreted as identifiers.